### PR TITLE
Adds support for the minimum and maximum dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This library uses window.matchMedia to control whether to show the one or two ca
 * ranges - Predefined ranges for the user to select. Defaults to [today, yesterday, last 7 days, last 30 days, this month, last month]
 * defaultValue - A moment range object with the default range you want selected. Defaults to this.props.ranges[2] (i.e. last 7 days)
 * alwaysShowCalendar - Controls whether the calendar always shows or only for custom ranges. Defaults to true.
+* minimumDate - The minimum date you want the user to be able to select
+* maximumDate - The maximum date you want the user to be able to select
 
 # Styles
 

--- a/lib/DateRangeInput.js
+++ b/lib/DateRangeInput.js
@@ -36,7 +36,9 @@ var DateRangeInput = _react2['default'].createClass({
       value: _react2['default'].PropTypes.object
     })),
     defaultValue: _react2['default'].PropTypes.object,
-    alwaysShowCalendar: _react2['default'].PropTypes.bool
+    alwaysShowCalendar: _react2['default'].PropTypes.bool,
+    maximumDate: _react2['default'].PropTypes.instanceOf(Date),
+    minimumDate: _react2['default'].PropTypes.instanceOf(Date)
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -241,12 +243,22 @@ var DateRangeInput = _react2['default'].createClass({
   },
 
   renderPicker: function renderPicker() {
-    return _react2['default'].createElement(_reactDaterangePicker2['default'], {
+    var props = {
       ref: 'dateRangePicker',
       numberOfCalendars: this.state.numCalendars,
       value: this.state.value,
       onSelect: this.handleDatePickerSelect
-    });
+    };
+
+    if (this.props.minimumDate) {
+      props.minimumDate = this.props.minimumDate;
+    }
+
+    if (this.props.maximumDate) {
+      props.maximumDate = this.props.maximumDate;
+    }
+
+    return _react2['default'].createElement(_reactDaterangePicker2['default'], props);
   },
 
   renderDropdown: function renderDropdown() {

--- a/modules/DateRangeInput.jsx
+++ b/modules/DateRangeInput.jsx
@@ -14,7 +14,9 @@ let DateRangeInput = React.createClass({
       value: React.PropTypes.object
     })),
     defaultValue: React.PropTypes.object,
-    alwaysShowCalendar: React.PropTypes.bool
+    alwaysShowCalendar: React.PropTypes.bool,
+    maximumDate: React.PropTypes.instanceOf(Date),
+    minimumDate: React.PropTypes.instanceOf(Date)
   },
 
   getDefaultProps() {
@@ -242,13 +244,23 @@ let DateRangeInput = React.createClass({
   },
 
   renderPicker() {
+    let props = {
+      ref: 'dateRangePicker',
+      numberOfCalendars: this.state.numCalendars,
+      value: this.state.value,
+      onSelect: this.handleDatePickerSelect
+    };
+
+    if (this.props.minimumDate) {
+      props.minimumDate = this.props.minimumDate;
+    }
+
+    if (this.props.maximumDate) {
+      props.maximumDate = this.props.maximumDate;
+    }
+
     return (
-      <DateRangePicker
-        ref="dateRangePicker"
-        numberOfCalendars={this.state.numCalendars}
-        value={this.state.value}
-        onSelect={this.handleDatePickerSelect}
-      />
+      <DateRangePicker {...props} />
     );
   },
 


### PR DESCRIPTION
The react-daterange-picker has support for a minimum date and maximum
date the user can select. This commit adds support to pass those values
through to the react-daterange-picker.