### PR TITLE
Do not show a default date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This library uses window.matchMedia to control whether to show the one or two ca
 * onDateSelected - Function to call when date range is selected.
 * ranges - Predefined ranges for the user to select. Defaults to [today, yesterday, last 7 days, last 30 days, this month, last month].
 * defaultValue - A moment range object with the default range you want selected. Defaults to `this.props.ranges[2]` (i.e. last 7 days).
-* ignoreDefault - Boolean value. If set to true then don't use the default date range.
 * alwaysShowCalendar - Controls whether the calendar always shows or only for custom ranges. Defaults to true.
 * minimumDate - The minimum date you want the user to be able to select.
 * maximumDate - The maximum date you want the user to be able to select.

--- a/example/example.js
+++ b/example/example.js
@@ -38356,7 +38356,7 @@ _reactDom2.default.render(_react2.default.createElement(_index2.default, {
   minimumDate: lastMonth,
   maximumDate: nextMonth,
   ranges: [],
-  ignoreDefault: true,
+  defaultValue: null,
   singleCalendarBreakpoint: 1260
 }), document.getElementById('dateRangeExampleNoRangesBlockedDates'));
 
@@ -38461,7 +38461,7 @@ var DateRangeInput = function (_Component) {
     var startDate = null;
     var endDate = null;
 
-    if (!props.ignoreDefault && props.defaultValue && props.defaultValue.start && props.defaultValue.end) {
+    if (props.defaultValue && props.defaultValue.start && props.defaultValue.end) {
       value = props.defaultValue;
       startDate = props.defaultValue.start;
       endDate = props.defaultValue.end;
@@ -38533,7 +38533,6 @@ DateRangeInput.propTypes = {
     value: _propTypes2.default.object
   })),
   defaultValue: _propTypes2.default.object,
-  ignoreDefault: _propTypes2.default.bool,
   alwaysShowCalendar: _propTypes2.default.bool,
   singleCalendarBreakpoint: _propTypes2.default.number,
   maximumDate: _propTypes2.default.instanceOf(Date),
@@ -38546,7 +38545,6 @@ DateRangeInput.propTypes = {
 DateRangeInput.defaultProps = {
   onDateSelected: function onDateSelected() {},
   defaultValue: defaultRanges[2].value,
-  ignoreDefault: false,
   alwaysShowCalendar: true,
   singleCalendarBreakpoint: 979,
   ranges: defaultRanges,
@@ -38602,7 +38600,7 @@ var _initialiseProps = function _initialiseProps() {
   this.hasValidDate = function () {
     var isValid = false;
 
-    if (_this3.state.value && _this3.state.value.start instanceof _moment2.default && _this3.state.value.start instanceof _moment2.default) {
+    if (_this3.state.value && _this3.state.value.start instanceof _moment2.default && _this3.state.value.end instanceof _moment2.default) {
       isValid = true;
     }
 
@@ -38698,11 +38696,19 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.clearSelectedRange = function () {
-    _this3.setState({
+    var clearValue = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+
+    var newState = {
       startDate: null,
       endDate: null,
       focusedInput: 'startDate'
-    });
+    };
+
+    if (clearValue) {
+      newState.value = null;
+    }
+
+    _this3.setState(newState);
   };
 
   this.handleIsOutsideRange = function (day) {

--- a/example/example.js
+++ b/example/example.js
@@ -60,7 +60,7 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 298);
+/******/ 	return __webpack_require__(__webpack_require__.s = 299);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -1896,7 +1896,7 @@ function loadLocale(name) {
             module && module.exports) {
         try {
             oldLocale = globalLocale._abbr;
-            __webpack_require__(357)("./" + name);
+            __webpack_require__(358)("./" + name);
             // because defineLocale currently also sets the global locale, we
             // want to undo that for lazy loaded locales
             getSetGlobalLocale(oldLocale);
@@ -4531,7 +4531,7 @@ return hooks;
 
 })));
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(356)(module)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(357)(module)))
 
 /***/ }),
 /* 1 */
@@ -4886,7 +4886,7 @@ if (process.env.NODE_ENV !== 'production') {
 } else {
   // By explicitly using `prop-types` you are opting into new production behavior.
   // http://fb.me/prop-types-in-prod
-  module.exports = __webpack_require__(315)();
+  module.exports = __webpack_require__(316)();
 }
 
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
@@ -5122,7 +5122,7 @@ module.exports = shouldUseNative() ? Object.assign : function (target, source) {
 
 var _prodInvariant = __webpack_require__(5);
 
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 var ReactDOMComponentFlags = __webpack_require__(247);
 
 var invariant = __webpack_require__(2);
@@ -5349,7 +5349,7 @@ module.exports = ExecutionEnvironment;
 /* 12 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(process) {module.exports = process.env.NODE_ENV === 'production' ? __webpack_require__(318) : __webpack_require__(319);
+/* WEBPACK VAR INJECTION */(function(process) {module.exports = process.env.NODE_ENV === 'production' ? __webpack_require__(319) : __webpack_require__(320);
 
 //# sourceMappingURL=index.js.map
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
@@ -6031,7 +6031,7 @@ var defineProperties = __webpack_require__(21);
 
 var implementation = __webpack_require__(99);
 var getPolyfill = __webpack_require__(100);
-var shim = __webpack_require__(325);
+var shim = __webpack_require__(326);
 
 var polyfill = getPolyfill();
 
@@ -6122,7 +6122,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
 var debugTool = null;
 
 if (process.env.NODE_ENV !== 'production') {
-  var ReactDebugTool = __webpack_require__(373);
+  var ReactDebugTool = __webpack_require__(374);
   debugTool = ReactDebugTool;
 }
 
@@ -6171,7 +6171,7 @@ module.exports = ReactCurrentOwner;
 
 
 var keys = __webpack_require__(67);
-var foreach = __webpack_require__(322);
+var foreach = __webpack_require__(323);
 var hasSymbols = typeof Symbol === 'function' && typeof Symbol() === 'symbol';
 
 var toStr = Object.prototype.toString;
@@ -6759,6 +6759,56 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
 /* 24 */
 /***/ (function(module, exports, __webpack_require__) {
 
+var moment = __webpack_require__(0);
+var momentValidationWrapper = __webpack_require__(449);
+var core = __webpack_require__(450);
+
+moment.createFromInputFallback = function(config) {
+  config._d = new Date(config._i);
+};
+
+module.exports = {
+
+  momentObj : core.createMomentChecker(
+    'object',
+    function(obj) {
+      return typeof obj === 'object';
+    },
+    function isValid(value) {
+      return momentValidationWrapper.isValidMoment(value);
+    },
+    'Moment'
+  ),
+
+  momentString : core.createMomentChecker(
+    'string',
+    function(str) {
+      return typeof str === 'string';
+    },
+    function isValid(value) {
+      return momentValidationWrapper.isValidMoment(moment(value));
+    },
+    'Moment'
+  ),
+
+  momentDurationObj : core.createMomentChecker(
+    'object',
+    function(obj) {
+      return typeof obj === 'object';
+    },
+    function isValid(value) {
+      return moment.isDuration(value);
+    },
+    'Duration'
+  ),
+
+};
+
+
+/***/ }),
+/* 25 */
+/***/ (function(module, exports, __webpack_require__) {
+
 "use strict";
 /* WEBPACK VAR INJECTION */(function(process) {/**
  * Copyright 2013-present, Facebook, Inc.
@@ -6969,56 +7019,6 @@ var DOMProperty = {
 
 module.exports = DOMProperty;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
-
-/***/ }),
-/* 25 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var moment = __webpack_require__(0);
-var momentValidationWrapper = __webpack_require__(448);
-var core = __webpack_require__(449);
-
-moment.createFromInputFallback = function(config) {
-  config._d = new Date(config._i);
-};
-
-module.exports = {
-
-  momentObj : core.createMomentChecker(
-    'object',
-    function(obj) {
-      return typeof obj === 'object';
-    },
-    function isValid(value) {
-      return momentValidationWrapper.isValidMoment(value);
-    },
-    'Moment'
-  ),
-
-  momentString : core.createMomentChecker(
-    'string',
-    function(str) {
-      return typeof str === 'string';
-    },
-    function isValid(value) {
-      return momentValidationWrapper.isValidMoment(moment(value));
-    },
-    'Moment'
-  ),
-
-  momentDurationObj : core.createMomentChecker(
-    'object',
-    function(obj) {
-      return typeof obj === 'object';
-    },
-    function isValid(value) {
-      return moment.isDuration(value);
-    },
-    'Duration'
-  ),
-
-};
-
 
 /***/ }),
 /* 26 */
@@ -7586,14 +7586,14 @@ exports['default'] = _propTypes2['default'].oneOf(_constants.WEEKDAYS);
 var _assign = __webpack_require__(9);
 
 var ReactBaseClasses = __webpack_require__(92);
-var ReactChildren = __webpack_require__(301);
-var ReactDOMFactories = __webpack_require__(305);
+var ReactChildren = __webpack_require__(302);
+var ReactDOMFactories = __webpack_require__(306);
 var ReactElement = __webpack_require__(26);
-var ReactPropTypes = __webpack_require__(309);
-var ReactVersion = __webpack_require__(311);
+var ReactPropTypes = __webpack_require__(310);
+var ReactVersion = __webpack_require__(312);
 
-var createReactClass = __webpack_require__(312);
-var onlyChild = __webpack_require__(314);
+var createReactClass = __webpack_require__(313);
+var onlyChild = __webpack_require__(315);
 
 var createElement = ReactElement.createElement;
 var createFactory = ReactElement.createFactory;
@@ -7752,7 +7752,7 @@ module.exports = reactProdInvariant;
 /* 32 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var implementation = __webpack_require__(323);
+var implementation = __webpack_require__(324);
 
 module.exports = Function.prototype.bind || implementation;
 
@@ -7796,7 +7796,7 @@ module.exports = exports['default'];
 
 
 
-var ReactRef = __webpack_require__(371);
+var ReactRef = __webpack_require__(372);
 var ReactInstrumentation = __webpack_require__(19);
 
 var warning = __webpack_require__(3);
@@ -9294,11 +9294,11 @@ exports.EVENT_HANDLERS_KEY = undefined;
 exports.addEventListener = addEventListener;
 exports.removeEventListener = removeEventListener;
 
-var _normalizeEventOptions = __webpack_require__(358);
+var _normalizeEventOptions = __webpack_require__(359);
 
 var _normalizeEventOptions2 = _interopRequireDefault(_normalizeEventOptions);
 
-var _TargetEventHandlers = __webpack_require__(361);
+var _TargetEventHandlers = __webpack_require__(362);
 
 var _TargetEventHandlers2 = _interopRequireDefault(_TargetEventHandlers);
 
@@ -9328,7 +9328,7 @@ function removeEventListener(unsubscribeFn) {
 "use strict";
 
 
-module.exports = __webpack_require__(363);
+module.exports = __webpack_require__(364);
 
 
 /***/ }),
@@ -10151,10 +10151,10 @@ module.exports = escapeTextContentForBrowser;
 var _assign = __webpack_require__(9);
 
 var EventPluginRegistry = __webpack_require__(58);
-var ReactEventEmitterMixin = __webpack_require__(397);
+var ReactEventEmitterMixin = __webpack_require__(398);
 var ViewportMetrics = __webpack_require__(255);
 
-var getVendorPrefixedEventName = __webpack_require__(398);
+var getVendorPrefixedEventName = __webpack_require__(399);
 var isEventSupported = __webpack_require__(76);
 
 /**
@@ -10591,7 +10591,7 @@ module.exports = ReactPropTypesSecret;
 var has = Object.prototype.hasOwnProperty;
 var toStr = Object.prototype.toString;
 var slice = Array.prototype.slice;
-var isArgs = __webpack_require__(321);
+var isArgs = __webpack_require__(322);
 var isEnumerable = Object.prototype.propertyIsEnumerable;
 var hasDontEnumBug = !isEnumerable.call({ toString: null }, 'toString');
 var hasProtoEnumBug = isEnumerable.call(function () {}, 'prototype');
@@ -10745,7 +10745,7 @@ var _object = __webpack_require__(17);
 
 var _object2 = _interopRequireDefault(_object);
 
-var _object3 = __webpack_require__(326);
+var _object3 = __webpack_require__(327);
 
 var _object4 = _interopRequireDefault(_object3);
 
@@ -11049,7 +11049,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports['default'] = getComponentName;
 
-var _functionPrototype = __webpack_require__(341);
+var _functionPrototype = __webpack_require__(342);
 
 var _functionPrototype2 = _interopRequireDefault(_functionPrototype);
 
@@ -11602,7 +11602,7 @@ module.exports = getEventModifierState;
 
 
 var DOMLazyTree = __webpack_require__(36);
-var Danger = __webpack_require__(382);
+var Danger = __webpack_require__(383);
 var ReactDOMComponentTree = __webpack_require__(10);
 var ReactInstrumentation = __webpack_require__(19);
 
@@ -13162,7 +13162,7 @@ module.exports = __webpack_require__(57);
 /* 46 */
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(459);
+module.exports = __webpack_require__(460);
 
 /***/ }),
 /* 47 */,
@@ -13182,13 +13182,13 @@ module.exports = __webpack_require__(288);
 /* 56 */
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(463);
+module.exports = __webpack_require__(464);
 
 /***/ }),
 /* 57 */
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(464);
+module.exports = __webpack_require__(465);
 
 /***/ }),
 /* 58 */,
@@ -14719,7 +14719,7 @@ var ReactCurrentOwner = __webpack_require__(20);
 var ReactComponentTreeHook = __webpack_require__(14);
 var ReactElement = __webpack_require__(26);
 
-var checkReactTypeSpec = __webpack_require__(306);
+var checkReactTypeSpec = __webpack_require__(307);
 
 var canDefineProperty = __webpack_require__(51);
 var getIteratorFn = __webpack_require__(95);
@@ -15001,7 +15001,7 @@ var invariant = __webpack_require__(2);
 var warning = __webpack_require__(3);
 
 var ReactPropTypesSecret = __webpack_require__(66);
-var checkPropTypes = __webpack_require__(310);
+var checkPropTypes = __webpack_require__(311);
 
 module.exports = function(isValidElement, throwOnDirectAccess) {
   /* global Symbol */
@@ -15513,7 +15513,7 @@ var bind = __webpack_require__(32);
 var canBeObject = function (obj) {
 	return typeof obj !== 'undefined' && obj !== null;
 };
-var hasSymbols = __webpack_require__(324)();
+var hasSymbols = __webpack_require__(325)();
 var toObject = Object;
 var push = bind.call(Function.call, Array.prototype.push);
 var propIsEnumerable = bind.call(Function.call, Object.prototype.propertyIsEnumerable);
@@ -15654,7 +15654,7 @@ module.exports = function entries(O) {
 "use strict";
 
 
-module.exports = __webpack_require__(327);
+module.exports = __webpack_require__(328);
 
 
 /***/ }),
@@ -15665,7 +15665,7 @@ module.exports = __webpack_require__(327);
 
 
 var has = __webpack_require__(33);
-var toPrimitive = __webpack_require__(328);
+var toPrimitive = __webpack_require__(329);
 
 var toStr = Object.prototype.toString;
 var hasSymbols = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
@@ -15677,9 +15677,9 @@ var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
 var assign = __webpack_require__(108);
 var sign = __webpack_require__(109);
 var mod = __webpack_require__(110);
-var isPrimitive = __webpack_require__(331);
+var isPrimitive = __webpack_require__(332);
 var parseInteger = parseInt;
-var bind = __webpack_require__(332);
+var bind = __webpack_require__(333);
 var arraySlice = bind.call(Function.call, Array.prototype.slice);
 var strSlice = bind.call(Function.call, String.prototype.slice);
 var isBinary = bind.call(Function.call, RegExp.prototype.test, /^0b[01]+$/i);
@@ -15704,7 +15704,7 @@ var trim = function (value) {
 	return replace(value, trimRegex, '');
 };
 
-var ES5 = __webpack_require__(334);
+var ES5 = __webpack_require__(335);
 
 var hasRegExpMatcher = __webpack_require__(111);
 
@@ -16434,7 +16434,7 @@ var ES = __webpack_require__(117);
 
 var implementation = __webpack_require__(118);
 var getPolyfill = __webpack_require__(119);
-var shim = __webpack_require__(340);
+var shim = __webpack_require__(341);
 
 var slice = Array.prototype.slice;
 
@@ -29006,11 +29006,11 @@ module.exports = CSSProperty;
 
 
 
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 var ReactDOMComponentTree = __webpack_require__(10);
 var ReactInstrumentation = __webpack_require__(19);
 
-var quoteAttributeValueForBrowser = __webpack_require__(396);
+var quoteAttributeValueForBrowser = __webpack_require__(397);
 var warning = __webpack_require__(3);
 
 var VALID_ATTRIBUTE_NAME_REGEX = new RegExp('^[' + DOMProperty.ATTRIBUTE_NAME_START_CHAR + '][' + DOMProperty.ATTRIBUTE_NAME_CHAR + ']*$');
@@ -29478,11 +29478,11 @@ module.exports = ReactDOMSelect;
 var _prodInvariant = __webpack_require__(5),
     _assign = __webpack_require__(9);
 
-var ReactCompositeComponent = __webpack_require__(404);
+var ReactCompositeComponent = __webpack_require__(405);
 var ReactEmptyComponent = __webpack_require__(264);
 var ReactHostComponent = __webpack_require__(265);
 
-var getNextDebugID = __webpack_require__(407);
+var getNextDebugID = __webpack_require__(408);
 var invariant = __webpack_require__(2);
 var warning = __webpack_require__(3);
 
@@ -29768,9 +29768,9 @@ module.exports = ReactHostComponent;
 var _prodInvariant = __webpack_require__(5);
 
 var ReactCurrentOwner = __webpack_require__(20);
-var REACT_ELEMENT_TYPE = __webpack_require__(408);
+var REACT_ELEMENT_TYPE = __webpack_require__(409);
 
-var getIteratorFn = __webpack_require__(409);
+var getIteratorFn = __webpack_require__(410);
 var invariant = __webpack_require__(2);
 var KeyEscapeUtils = __webpack_require__(84);
 var warning = __webpack_require__(3);
@@ -30037,9 +30037,9 @@ module.exports = EventListener;
 
 
 
-var ReactDOMSelection = __webpack_require__(421);
+var ReactDOMSelection = __webpack_require__(422);
 
-var containsNode = __webpack_require__(423);
+var containsNode = __webpack_require__(424);
 var focusNode = __webpack_require__(257);
 var getActiveElement = __webpack_require__(269);
 
@@ -30240,17 +30240,17 @@ module.exports = g;
 var _prodInvariant = __webpack_require__(5);
 
 var DOMLazyTree = __webpack_require__(36);
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 var React = __webpack_require__(30);
 var ReactBrowserEventEmitter = __webpack_require__(63);
 var ReactCurrentOwner = __webpack_require__(20);
 var ReactDOMComponentTree = __webpack_require__(10);
-var ReactDOMContainerInfo = __webpack_require__(438);
-var ReactDOMFeatureFlags = __webpack_require__(439);
+var ReactDOMContainerInfo = __webpack_require__(439);
+var ReactDOMFeatureFlags = __webpack_require__(440);
 var ReactFeatureFlags = __webpack_require__(252);
 var ReactInstanceMap = __webpack_require__(48);
 var ReactInstrumentation = __webpack_require__(19);
-var ReactMarkupChecksum = __webpack_require__(440);
+var ReactMarkupChecksum = __webpack_require__(441);
 var ReactReconciler = __webpack_require__(35);
 var ReactUpdateQueue = __webpack_require__(85);
 var ReactUpdates = __webpack_require__(22);
@@ -31040,7 +31040,7 @@ var _propTypes = __webpack_require__(4);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _reactMomentProptypes = __webpack_require__(25);
+var _reactMomentProptypes = __webpack_require__(24);
 
 var _reactMomentProptypes2 = _interopRequireDefault(_reactMomentProptypes);
 
@@ -31290,7 +31290,7 @@ module.exports = __webpack_require__(12);
 /***/ 10:
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(25);
+module.exports = __webpack_require__(24);
 
 /***/ }),
 
@@ -33084,7 +33084,7 @@ module.exports = __webpack_require__(34);
 /* 281 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var debounce = __webpack_require__(450),
+var debounce = __webpack_require__(451),
     isObject = __webpack_require__(89);
 
 /** Error message constants. */
@@ -33159,7 +33159,7 @@ module.exports = throttle;
 /* 282 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var freeGlobal = __webpack_require__(452);
+var freeGlobal = __webpack_require__(453);
 
 /** Detect free variable `self`. */
 var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
@@ -33314,7 +33314,7 @@ module.exports = __webpack_require__(34);
 /* 10 */
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(25);
+module.exports = __webpack_require__(24);
 
 /***/ }),
 /* 11 */,
@@ -34975,7 +34975,7 @@ module.exports = __webpack_require__(40);
 /* 10 */
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(25);
+module.exports = __webpack_require__(24);
 
 /***/ }),
 /* 11 */,
@@ -35060,7 +35060,7 @@ module.exports = __webpack_require__(287);
 /* 50 */
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(460);
+module.exports = __webpack_require__(461);
 
 /***/ }),
 /* 51 */,
@@ -35572,7 +35572,7 @@ module.exports = __webpack_require__(12);
 /***/ 10:
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(25);
+module.exports = __webpack_require__(24);
 
 /***/ }),
 
@@ -35628,7 +35628,7 @@ module.exports = __webpack_require__(4);
 /***/ 47:
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(461);
+module.exports = __webpack_require__(462);
 
 /***/ }),
 
@@ -36023,7 +36023,7 @@ module.exports = __webpack_require__(12);
 /***/ 10:
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(25);
+module.exports = __webpack_require__(24);
 
 /***/ }),
 
@@ -36058,7 +36058,7 @@ module.exports = __webpack_require__(4);
 /***/ 48:
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(462);
+module.exports = __webpack_require__(463);
 
 /***/ }),
 
@@ -36397,7 +36397,7 @@ var define = __webpack_require__(21);
 
 var implementation = __webpack_require__(292);
 var getPolyfill = __webpack_require__(293);
-var shim = __webpack_require__(465);
+var shim = __webpack_require__(466);
 
 var polyfill = getPolyfill();
 
@@ -36485,7 +36485,7 @@ var _propTypes = __webpack_require__(4);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _reactMomentProptypes = __webpack_require__(25);
+var _reactMomentProptypes = __webpack_require__(24);
 
 var _reactMomentProptypes2 = _interopRequireDefault(_reactMomentProptypes);
 
@@ -36712,7 +36712,7 @@ module.exports = __webpack_require__(34);
 /* 10 */
 /***/ (function(module, exports) {
 
-module.exports = __webpack_require__(25);
+module.exports = __webpack_require__(24);
 
 /***/ }),
 /* 11 */,
@@ -38319,10 +38319,415 @@ SingleDatePickerInput.defaultProps = defaultProps;
 /* 298 */
 /***/ (function(module, exports, __webpack_require__) {
 
+var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (root, factory) {
+  if (true) {
+    // AMD. Register as an anonymous module unless amdModuleId is set
+    !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0)], __WEBPACK_AMD_DEFINE_RESULT__ = function (a0) {
+      return (root['DateRange'] = factory(a0));
+    }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory(require("moment"));
+  } else {
+    root['DateRange'] = factory(moment);
+  }
+}(this, function (moment) {
+
+//-----------------------------------------------------------------------------
+// Contstants
+//-----------------------------------------------------------------------------
+
+
+
+var INTERVALS = {
+  year:   true,
+  month:  true,
+  week:   true,
+  day:    true,
+  hour:   true,
+  minute: true,
+  second: true
+};
+
+
+//-----------------------------------------------------------------------------
+// Date Ranges
+//-----------------------------------------------------------------------------
+
+/**
+ * DateRange class to store ranges and query dates.
+ *
+ * @constructor
+ * @param {(Moment|Date)} start Start of interval
+ * @param {(Moment|Date)} end End of interval
+ *//**
+ * DateRange class to store ranges and query dates.
+ *
+ * @constructor
+ * @param {!Array} range Array containing start and end dates.
+ *//**
+ * DateRange class to store ranges and query dates.
+ *
+ * @constructor
+ * @param {!String} range String formatted as an IS0 8601 time interval
+ */
+function DateRange(start, end) {
+  var parts;
+  var s = start;
+  var e = end;
+
+  if (arguments.length === 1 || end === undefined) {
+    if (typeof start === 'object' && start.length === 2) {
+      s = start[0];
+      e = start[1];
+    }
+    else if (typeof start === 'string') {
+      parts = start.split('/');
+      s = parts[0];
+      e = parts[1];
+    }
+  }
+
+  this.start = (s === null) ? moment(-8640000000000000) : moment(s);
+  this.end   = (e === null) ? moment(8640000000000000) : moment(e);
+}
+
+/**
+ * Constructor for prototype.
+ *
+ * @type {DateRange}
+ */
+DateRange.prototype.constructor = DateRange;
+
+/**
+ * Deep clone range.
+ *
+ * @return {!DateRange}
+ */
+DateRange.prototype.clone = function() {
+  return moment().range(this.start, this.end);
+};
+
+/**
+ * Determine if the current interval contains a given moment/date/range.
+ *
+ * @param {(Moment|Date|DateRange)} other Date to check
+ * @param {!boolean} exclusive True if the to value is exclusive
+ *
+ * @return {!boolean}
+ */
+DateRange.prototype.contains = function(other, exclusive) {
+  var start = this.start;
+  var end   = this.end;
+
+  if (other instanceof DateRange) {
+    return start <= other.start && (end > other.end || (end.isSame(other.end) && !exclusive));
+  }
+  else {
+    return start <= other && (end > other || (end.isSame(other) && !exclusive));
+  }
+};
+
+/**
+ * Determine if the current date range overlaps a given date range.
+ *
+ * @param {!DateRange} range Date range to check
+ *
+ * @return {!boolean}
+ */
+DateRange.prototype.overlaps = function(range) {
+  return this.intersect(range) !== null;
+};
+
+/**
+ * Determine the intersecting periods from one or more date ranges.
+ *
+ * @param {!DateRange} other A date range to intersect with this one
+ *
+ * @return {DateRange} Returns the intersecting date or `null` if the ranges do
+ *                     not intersect
+ */
+DateRange.prototype.intersect = function(other) {
+  var start = this.start;
+  var end   = this.end;
+
+  if ((start <= other.start) && (other.start < end) && (end < other.end)) {
+    return new DateRange(other.start, end);
+  }
+  else if ((other.start < start) && (start < other.end) && (other.end <= end)) {
+    return new DateRange(start, other.end);
+  }
+  else if ((other.start < start) && (start <= end) && (end < other.end)) {
+    return this;
+  }
+  else if ((start <= other.start) && (other.start <= other.end) && (other.end <= end)) {
+    return other;
+  }
+
+  return null;
+};
+
+/**
+ * Merge date ranges if they intersect.
+ *
+ * @param {!DateRange} other A date range to add to this one
+ *
+ * @return {DateRange} Returns the new `DateRange` or `null` if they do not
+ *                     overlap
+ */
+DateRange.prototype.add = function(other) {
+  if (this.overlaps(other)) {
+    return new DateRange(moment.min(this.start, other.start), moment.max(this.end, other.end));
+  }
+
+  return null;
+};
+
+/**
+ * Subtract one range from another.
+ *
+ * @param {!DateRange} other A date range to substract from this one
+ *
+ * @return {!Array<DateRange>}
+ */
+DateRange.prototype.subtract = function(other) {
+  var start = this.start;
+  var end   = this.end;
+
+  if (this.intersect(other) === null) {
+    return [this];
+  }
+  else if ((other.start <= start) && (start < end) && (end <= other.end)) {
+    return [];
+  }
+  else if ((other.start <= start) && (start < other.end) && (other.end < end)) {
+    return [new DateRange(other.end, end)];
+  }
+  else if ((start < other.start) && (other.start < end) && (end <= other.end)) {
+    return [new DateRange(start, other.start)];
+  }
+  else if ((start < other.start) && (other.start < other.end) && (other.end < end)) {
+    return [new DateRange(start, other.start), new DateRange(other.end, end)];
+  }
+  else if ((start < other.start) && (other.start < end) && (other.end < end)) {
+    return [new DateRange(start, other.start), new DateRange(other.start, end)];
+  }
+};
+
+/**
+ * Build a n array of dates.
+ *
+ * @param {(!DateRange|String)} range Date range to be used for iteration or
+ *                                    shorthand string (shorthands:
+ *                                    http://momentjs.com/docs/#/manipulating/add/)
+ * @param {!boolean} exclusive Indicate that the end of the range should not
+ *                             be included in the iter.
+ *
+ * @return {!Array}
+ */
+DateRange.prototype.toArray = function(by, exclusive) {
+  var acc = [];
+  this.by(by, function(unit) {
+    acc.push(unit);
+  }, exclusive);
+  return acc;
+};
+
+/**
+ * Iterate over the date range by a given date range, executing a function
+ * for each sub-range.
+ *
+ * @param {(!DateRange|String)} range Date range to be used for iteration or
+ *                                    shorthand string (shorthands:
+ *                                    http://momentjs.com/docs/#/manipulating/add/)
+ * @param {!DateRange~by} hollaback Callback
+ * @param {!boolean} exclusive Indicate that the end of the range should not
+ *                             be included in the iter.
+ *
+ * @return {DateRange} `this`
+ */
+DateRange.prototype.by = function(range, hollaback, exclusive) {
+  if (typeof range === 'string') {
+    _byString.call(this, range, hollaback, exclusive);
+  }
+  else {
+    _byRange.call(this, range, hollaback, exclusive);
+  }
+  return this;
+};
+
+
+/**
+ * Callback executed for each sub-range.
+ *
+ * @callback DateRange~by
+ *
+ * @param {!Moment} current Current moment object for iteration
+ */
+
+/**
+ * @private
+ */
+function _byString(interval, hollaback, exclusive) {
+  var current = moment(this.start);
+
+  while (this.contains(current, exclusive)) {
+    hollaback.call(this, current.clone());
+    current.add(1, interval);
+  }
+}
+
+/**
+ * @private
+ */
+function _byRange(interval, hollaback, exclusive) {
+  var div = this / interval;
+  var l = Math.floor(div);
+
+  if (l === Infinity) { return; }
+  if (l === div && exclusive) {
+    l--;
+  }
+
+  for (var i = 0; i <= l; i++) {
+    hollaback.call(this, moment(this.start.valueOf() + interval.valueOf() * i));
+  }
+}
+
+/**
+ * Date range formatted as an [ISO8601 Time
+ * Interval](http://en.wikipedia.org/wiki/ISO_8601#Time_intervals).
+ *
+ * @return {!String}
+ */
+DateRange.prototype.toString = function() {
+  return this.start.format() + '/' + this.end.format();
+};
+
+/**
+ * Date range in milliseconds. Allows basic coercion math of date ranges.
+ *
+ * @return {!number}
+ */
+DateRange.prototype.valueOf = function() {
+  return this.end - this.start;
+};
+
+/**
+ * Center date of the range.
+ *
+ * @return {!Moment}
+ */
+DateRange.prototype.center = function() {
+  var center = this.start + this.diff() / 2;
+  return moment(center);
+};
+
+/**
+ * Date range toDate
+ *
+ * @return {!Array<Date>}
+ */
+DateRange.prototype.toDate = function() {
+  return [this.start.toDate(), this.end.toDate()];
+};
+
+/**
+ * Determine if this date range is the same as another.
+ *
+ * @param {!DateRange} other Another date range to compare to
+ *
+ * @return {!boolean}
+ */
+DateRange.prototype.isSame = function(other) {
+  return this.start.isSame(other.start) && this.end.isSame(other.end);
+};
+
+/**
+ * The difference of the end vs start.
+ *
+ * @param {number} unit Unit of difference, if no unit is passed in
+ *                      milliseconds are returned. E.g.: `"days"`, `"months"`,
+ *                      etc...
+ *
+ * @return {!number}
+ */
+DateRange.prototype.diff = function(unit) {
+  return this.end.diff(this.start, unit);
+};
+
+
+//-----------------------------------------------------------------------------
+// Moment Extensions
+//-----------------------------------------------------------------------------
+
+/**
+ * Build a date range.
+ *
+ * @param {(Moment|Date)} start Start of range
+ * @param {(Moment|Date)} end End of range
+ *
+ * @this {Moment}
+ *
+ * @return {!DateRange}
+ */
+moment.range = function(start, end) {
+  if (start in INTERVALS) {
+    return new DateRange(moment(this).startOf(start), moment(this).endOf(start));
+  }
+  else {
+    return new DateRange(start, end);
+  }
+};
+
+/**
+ * Expose constructor
+ *
+ * @const
+ */
+moment.range.constructor = DateRange;
+
+/**
+ * @deprecated
+ */
+moment.fn.range = moment.range;
+
+/**
+ * Check if the current moment is within a given date range.
+ *
+ * @param {!DateRange} range Date range to check
+ *
+ * @this {Moment}
+ *
+ * @return {!boolean}
+ */
+moment.fn.within = function(range) {
+  return range.contains(this._d);
+};
+
+
+//-----------------------------------------------------------------------------
+// Export
+//-----------------------------------------------------------------------------
+
+
+
+return DateRange;
+
+}));
+
+
+/***/ }),
+/* 299 */
+/***/ (function(module, exports, __webpack_require__) {
+
 "use strict";
 
 
-var _index = __webpack_require__(299);
+var _index = __webpack_require__(300);
 
 var _index2 = _interopRequireDefault(_index);
 
@@ -38333,6 +38738,12 @@ var _react2 = _interopRequireDefault(_react);
 var _reactDom = __webpack_require__(57);
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
+
+var _moment = __webpack_require__(0);
+
+var _moment2 = _interopRequireDefault(_moment);
+
+__webpack_require__(298);
 
 __webpack_require__(469);
 
@@ -38348,9 +38759,14 @@ lastMonth.setDate(14);
 nextMonth.setMonth(date.getMonth() + 1);
 nextMonth.setDate(16);
 
-_reactDom2.default.render(_react2.default.createElement(_index2.default, null), document.getElementById('dateRangeExample'));
+_reactDom2.default.render(_react2.default.createElement(_index2.default, {
+  defaultValue: _moment2.default.range((0, _moment2.default)().startOf('day').subtract(6, 'days'), (0, _moment2.default)().startOf('day'))
+}), document.getElementById('dateRangeExample'));
 
-_reactDom2.default.render(_react2.default.createElement(_index2.default, { ranges: [] }), document.getElementById('dateRangeExampleNoRanges'));
+_reactDom2.default.render(_react2.default.createElement(_index2.default, {
+  ranges: [],
+  defaultValue: _moment2.default.range((0, _moment2.default)().startOf('day').subtract(6, 'days'), (0, _moment2.default)().startOf('day'))
+}), document.getElementById('dateRangeExampleNoRanges'));
 
 _reactDom2.default.render(_react2.default.createElement(_index2.default, {
   minimumDate: lastMonth,
@@ -38361,7 +38777,7 @@ _reactDom2.default.render(_react2.default.createElement(_index2.default, {
 }), document.getElementById('dateRangeExampleNoRangesBlockedDates'));
 
 /***/ }),
-/* 299 */
+/* 300 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38371,7 +38787,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _DateRangeInput = __webpack_require__(300);
+var _DateRangeInput = __webpack_require__(301);
 
 Object.defineProperty(exports, 'default', {
   enumerable: true,
@@ -38383,7 +38799,7 @@ Object.defineProperty(exports, 'default', {
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /***/ }),
-/* 300 */
+/* 301 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38403,13 +38819,17 @@ var _propTypes = __webpack_require__(4);
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _reactDates = __webpack_require__(316);
+var _reactDates = __webpack_require__(317);
+
+var _reactMomentProptypes = __webpack_require__(24);
+
+var _reactMomentProptypes2 = _interopRequireDefault(_reactMomentProptypes);
 
 var _moment = __webpack_require__(0);
 
 var _moment2 = _interopRequireDefault(_moment);
 
-__webpack_require__(468);
+__webpack_require__(298);
 
 var _classnames2 = __webpack_require__(18);
 
@@ -38530,9 +38950,9 @@ DateRangeInput.propTypes = {
   onDateSelected: _propTypes2.default.func,
   ranges: _propTypes2.default.arrayOf(_propTypes2.default.shape({
     label: _propTypes2.default.string,
-    value: _propTypes2.default.object
+    value: _reactMomentProptypes2.default.momentObj
   })),
-  defaultValue: _propTypes2.default.object,
+  defaultValue: _reactMomentProptypes2.default.momentObj,
   alwaysShowCalendar: _propTypes2.default.bool,
   singleCalendarBreakpoint: _propTypes2.default.number,
   maximumDate: _propTypes2.default.instanceOf(Date),
@@ -38544,7 +38964,7 @@ DateRangeInput.propTypes = {
 };
 DateRangeInput.defaultProps = {
   onDateSelected: function onDateSelected() {},
-  defaultValue: defaultRanges[2].value,
+  defaultValue: null,
   alwaysShowCalendar: true,
   singleCalendarBreakpoint: 979,
   ranges: defaultRanges,
@@ -38886,7 +39306,7 @@ var _initialiseProps = function _initialiseProps() {
 exports.default = DateRangeInput;
 
 /***/ }),
-/* 301 */
+/* 302 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -38902,11 +39322,11 @@ exports.default = DateRangeInput;
 
 
 
-var PooledClass = __webpack_require__(302);
+var PooledClass = __webpack_require__(303);
 var ReactElement = __webpack_require__(26);
 
 var emptyFunction = __webpack_require__(16);
-var traverseAllChildren = __webpack_require__(303);
+var traverseAllChildren = __webpack_require__(304);
 
 var twoArgumentPooler = PooledClass.twoArgumentPooler;
 var fourArgumentPooler = PooledClass.fourArgumentPooler;
@@ -39082,7 +39502,7 @@ var ReactChildren = {
 module.exports = ReactChildren;
 
 /***/ }),
-/* 302 */
+/* 303 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39200,7 +39620,7 @@ module.exports = PooledClass;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 303 */
+/* 304 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39223,7 +39643,7 @@ var REACT_ELEMENT_TYPE = __webpack_require__(94);
 
 var getIteratorFn = __webpack_require__(95);
 var invariant = __webpack_require__(2);
-var KeyEscapeUtils = __webpack_require__(304);
+var KeyEscapeUtils = __webpack_require__(305);
 var warning = __webpack_require__(3);
 
 var SEPARATOR = '.';
@@ -39382,7 +39802,7 @@ module.exports = traverseAllChildren;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 304 */
+/* 305 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39446,7 +39866,7 @@ var KeyEscapeUtils = {
 module.exports = KeyEscapeUtils;
 
 /***/ }),
-/* 305 */
+/* 306 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39621,7 +40041,7 @@ module.exports = ReactDOMFactories;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 306 */
+/* 307 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39639,8 +40059,8 @@ module.exports = ReactDOMFactories;
 
 var _prodInvariant = __webpack_require__(31);
 
-var ReactPropTypeLocationNames = __webpack_require__(307);
-var ReactPropTypesSecret = __webpack_require__(308);
+var ReactPropTypeLocationNames = __webpack_require__(308);
+var ReactPropTypesSecret = __webpack_require__(309);
 
 var invariant = __webpack_require__(2);
 var warning = __webpack_require__(3);
@@ -39714,7 +40134,7 @@ module.exports = checkReactTypeSpec;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 307 */
+/* 308 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39745,7 +40165,7 @@ module.exports = ReactPropTypeLocationNames;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 308 */
+/* 309 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39767,7 +40187,7 @@ var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
 module.exports = ReactPropTypesSecret;
 
 /***/ }),
-/* 309 */
+/* 310 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39791,7 +40211,7 @@ var factory = __webpack_require__(97);
 module.exports = factory(isValidElement);
 
 /***/ }),
-/* 310 */
+/* 311 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39860,7 +40280,7 @@ module.exports = checkPropTypes;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 311 */
+/* 312 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39879,7 +40299,7 @@ module.exports = checkPropTypes;
 module.exports = '15.6.1';
 
 /***/ }),
-/* 312 */
+/* 313 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -39902,12 +40322,12 @@ var _require2 = __webpack_require__(26),
     isValidElement = _require2.isValidElement;
 
 var ReactNoopUpdateQueue = __webpack_require__(93);
-var factory = __webpack_require__(313);
+var factory = __webpack_require__(314);
 
 module.exports = factory(Component, isValidElement, ReactNoopUpdateQueue);
 
 /***/ }),
-/* 313 */
+/* 314 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40787,7 +41207,7 @@ module.exports = factory;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 314 */
+/* 315 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40831,7 +41251,7 @@ module.exports = onlyChild;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 315 */
+/* 316 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -40897,13 +41317,13 @@ module.exports = function() {
 
 
 /***/ }),
-/* 316 */
+/* 317 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var DateRangePicker = __webpack_require__(317).default;
+var DateRangePicker = __webpack_require__(318).default;
 var DateRangePickerInput = __webpack_require__(279).default;
 var DateRangePickerInputController = __webpack_require__(278).default;
-var SingleDatePicker = __webpack_require__(466).default;
+var SingleDatePicker = __webpack_require__(467).default;
 var SingleDatePickerInput = __webpack_require__(297).default;
 var DayPicker = __webpack_require__(91).default;
 var DayPickerRangeController = __webpack_require__(284).default;
@@ -40916,7 +41336,7 @@ var DateRangePickerShape = __webpack_require__(274).default;
 var SingleDatePickerShape = __webpack_require__(295).default;
 
 var isInclusivelyAfterDay = __webpack_require__(43).default;
-var isInclusivelyBeforeDay = __webpack_require__(467).default;
+var isInclusivelyBeforeDay = __webpack_require__(468).default;
 var isNextDay = __webpack_require__(294).default;
 var isSameDay = __webpack_require__(41).default;
 
@@ -40954,7 +41374,7 @@ module.exports = {
 
 
 /***/ }),
-/* 317 */
+/* 318 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports =
@@ -41917,7 +42337,7 @@ DateRangePicker.defaultProps = defaultProps;
 /******/ ]);
 
 /***/ }),
-/* 318 */
+/* 319 */
 /***/ (function(module, exports) {
 
 function noop() {
@@ -41961,10 +42381,10 @@ module.exports = {
 //# sourceMappingURL=index.js.map
 
 /***/ }),
-/* 319 */
+/* 320 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var _propTypesExact = __webpack_require__(320);
+var _propTypesExact = __webpack_require__(321);
 
 var _propTypesExact2 = _interopRequireDefault(_propTypesExact);
 
@@ -41976,31 +42396,31 @@ var _between = __webpack_require__(68);
 
 var _between2 = _interopRequireDefault(_between);
 
-var _childrenHavePropXorChildren = __webpack_require__(337);
+var _childrenHavePropXorChildren = __webpack_require__(338);
 
 var _childrenHavePropXorChildren2 = _interopRequireDefault(_childrenHavePropXorChildren);
 
-var _childrenOf = __webpack_require__(338);
+var _childrenOf = __webpack_require__(339);
 
 var _childrenOf2 = _interopRequireDefault(_childrenOf);
 
-var _childrenOfType = __webpack_require__(339);
+var _childrenOfType = __webpack_require__(340);
 
 var _childrenOfType2 = _interopRequireDefault(_childrenOfType);
 
-var _childrenSequenceOf = __webpack_require__(343);
+var _childrenSequenceOf = __webpack_require__(344);
 
 var _childrenSequenceOf2 = _interopRequireDefault(_childrenSequenceOf);
 
-var _componentWithName = __webpack_require__(344);
+var _componentWithName = __webpack_require__(345);
 
 var _componentWithName2 = _interopRequireDefault(_componentWithName);
 
-var _elementType = __webpack_require__(345);
+var _elementType = __webpack_require__(346);
 
 var _elementType2 = _interopRequireDefault(_elementType);
 
-var _explicitNull = __webpack_require__(346);
+var _explicitNull = __webpack_require__(347);
 
 var _explicitNull2 = _interopRequireDefault(_explicitNull);
 
@@ -42008,19 +42428,19 @@ var _integer = __webpack_require__(72);
 
 var _integer2 = _interopRequireDefault(_integer);
 
-var _keysOf = __webpack_require__(347);
+var _keysOf = __webpack_require__(348);
 
 var _keysOf2 = _interopRequireDefault(_keysOf);
 
-var _mutuallyExclusiveProps = __webpack_require__(348);
+var _mutuallyExclusiveProps = __webpack_require__(349);
 
 var _mutuallyExclusiveProps2 = _interopRequireDefault(_mutuallyExclusiveProps);
 
-var _mutuallyExclusiveTrueProps = __webpack_require__(349);
+var _mutuallyExclusiveTrueProps = __webpack_require__(350);
 
 var _mutuallyExclusiveTrueProps2 = _interopRequireDefault(_mutuallyExclusiveTrueProps);
 
-var _nChildren = __webpack_require__(350);
+var _nChildren = __webpack_require__(351);
 
 var _nChildren2 = _interopRequireDefault(_nChildren);
 
@@ -42032,7 +42452,7 @@ var _nonNegativeNumber = __webpack_require__(126);
 
 var _nonNegativeNumber2 = _interopRequireDefault(_nonNegativeNumber);
 
-var _numericString = __webpack_require__(351);
+var _numericString = __webpack_require__(352);
 
 var _numericString2 = _interopRequireDefault(_numericString);
 
@@ -42040,15 +42460,15 @@ var _object = __webpack_require__(127);
 
 var _object2 = _interopRequireDefault(_object);
 
-var _or = __webpack_require__(352);
+var _or = __webpack_require__(353);
 
 var _or2 = _interopRequireDefault(_or);
 
-var _range = __webpack_require__(353);
+var _range = __webpack_require__(354);
 
 var _range2 = _interopRequireDefault(_range);
 
-var _restrictedProp = __webpack_require__(354);
+var _restrictedProp = __webpack_require__(355);
 
 var _restrictedProp2 = _interopRequireDefault(_restrictedProp);
 
@@ -42064,7 +42484,7 @@ var _uniqueArray = __webpack_require__(130);
 
 var _uniqueArray2 = _interopRequireDefault(_uniqueArray);
 
-var _uniqueArrayOf = __webpack_require__(355);
+var _uniqueArrayOf = __webpack_require__(356);
 
 var _uniqueArrayOf2 = _interopRequireDefault(_uniqueArrayOf);
 
@@ -42111,7 +42531,7 @@ module.exports = {
 //# sourceMappingURL=index.js.map
 
 /***/ }),
-/* 320 */
+/* 321 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -42173,7 +42593,7 @@ module.exports = exports['default'];
 //# sourceMappingURL=index.js.map
 
 /***/ }),
-/* 321 */
+/* 322 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42197,7 +42617,7 @@ module.exports = function isArguments(value) {
 
 
 /***/ }),
-/* 322 */
+/* 323 */
 /***/ (function(module, exports) {
 
 
@@ -42225,7 +42645,7 @@ module.exports = function forEach (obj, fn, ctx) {
 
 
 /***/ }),
-/* 323 */
+/* 324 */
 /***/ (function(module, exports) {
 
 var ERROR_MESSAGE = 'Function.prototype.bind called on incompatible ';
@@ -42279,7 +42699,7 @@ module.exports = function bind(that) {
 
 
 /***/ }),
-/* 324 */
+/* 325 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42327,7 +42747,7 @@ module.exports = function hasSymbols() {
 
 
 /***/ }),
-/* 325 */
+/* 326 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42348,7 +42768,7 @@ module.exports = function shimAssign() {
 
 
 /***/ }),
-/* 326 */
+/* 327 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42358,7 +42778,7 @@ var define = __webpack_require__(21);
 
 var implementation = __webpack_require__(102);
 var getPolyfill = __webpack_require__(112);
-var shim = __webpack_require__(336);
+var shim = __webpack_require__(337);
 
 var polyfill = getPolyfill();
 
@@ -42372,7 +42792,7 @@ module.exports = polyfill;
 
 
 /***/ }),
-/* 327 */
+/* 328 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42395,7 +42815,7 @@ module.exports = ES2016;
 
 
 /***/ }),
-/* 328 */
+/* 329 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42405,8 +42825,8 @@ var hasSymbols = typeof Symbol === 'function' && typeof Symbol.iterator === 'sym
 
 var isPrimitive = __webpack_require__(105);
 var isCallable = __webpack_require__(53);
-var isDate = __webpack_require__(329);
-var isSymbol = __webpack_require__(330);
+var isDate = __webpack_require__(330);
+var isSymbol = __webpack_require__(331);
 
 var ordinaryToPrimitive = function OrdinaryToPrimitive(O, hint) {
 	if (typeof O === 'undefined' || O === null) {
@@ -42476,7 +42896,7 @@ module.exports = function ToPrimitive(input, PreferredType) {
 
 
 /***/ }),
-/* 329 */
+/* 330 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42503,7 +42923,7 @@ module.exports = function isDateObject(value) {
 
 
 /***/ }),
-/* 330 */
+/* 331 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42537,7 +42957,7 @@ if (hasSymbols) {
 
 
 /***/ }),
-/* 331 */
+/* 332 */
 /***/ (function(module, exports) {
 
 module.exports = function isPrimitive(value) {
@@ -42546,19 +42966,19 @@ module.exports = function isPrimitive(value) {
 
 
 /***/ }),
-/* 332 */
+/* 333 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-var implementation = __webpack_require__(333);
+var implementation = __webpack_require__(334);
 
 module.exports = Function.prototype.bind || implementation;
 
 
 /***/ }),
-/* 333 */
+/* 334 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42617,7 +43037,7 @@ module.exports = function bind(that) {
 
 
 /***/ }),
-/* 334 */
+/* 335 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42630,7 +43050,7 @@ var sign = __webpack_require__(109);
 var mod = __webpack_require__(110);
 
 var IsCallable = __webpack_require__(53);
-var toPrimitive = __webpack_require__(335);
+var toPrimitive = __webpack_require__(336);
 
 var has = __webpack_require__(33);
 
@@ -42860,7 +43280,7 @@ module.exports = ES5;
 
 
 /***/ }),
-/* 335 */
+/* 336 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42904,7 +43324,7 @@ module.exports = function ToPrimitive(input, PreferredType) {
 
 
 /***/ }),
-/* 336 */
+/* 337 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -42925,7 +43345,7 @@ module.exports = function shimEntries() {
 
 
 /***/ }),
-/* 337 */
+/* 338 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -42991,7 +43411,7 @@ function childrenHavePropXorChildren(prop) {
 //# sourceMappingURL=childrenHavePropXorChildren.js.map
 
 /***/ }),
-/* 338 */
+/* 339 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43072,7 +43492,7 @@ function childrenOf(propType) {
 //# sourceMappingURL=childrenOf.js.map
 
 /***/ }),
-/* 339 */
+/* 340 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43142,7 +43562,7 @@ exports['default'] = childrenOfType;
 //# sourceMappingURL=childrenOfType.js.map
 
 /***/ }),
-/* 340 */
+/* 341 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -43165,7 +43585,7 @@ module.exports = function shimArrayPrototypeFind() {
 
 
 /***/ }),
-/* 341 */
+/* 342 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -43176,7 +43596,7 @@ var bind = __webpack_require__(32);
 
 var implementation = __webpack_require__(120);
 var getPolyfill = __webpack_require__(122);
-var shim = __webpack_require__(342);
+var shim = __webpack_require__(343);
 
 var bound = bind.call(Function.call, implementation);
 
@@ -43190,7 +43610,7 @@ module.exports = bound;
 
 
 /***/ }),
-/* 342 */
+/* 343 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -43232,7 +43652,7 @@ module.exports = function shimName() {
 
 
 /***/ }),
-/* 343 */
+/* 344 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43314,7 +43734,7 @@ function childrenSequenceOfValidator() {
 //# sourceMappingURL=childrenSequenceOf.js.map
 
 /***/ }),
-/* 344 */
+/* 345 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43414,7 +43834,7 @@ function componentWithName(name) {
 //# sourceMappingURL=componentWithName.js.map
 
 /***/ }),
-/* 345 */
+/* 346 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43491,7 +43911,7 @@ function elementTypeValidator(Type) {
 //# sourceMappingURL=elementType.js.map
 
 /***/ }),
-/* 346 */
+/* 347 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43529,7 +43949,7 @@ exports['default'] = function () {
 //# sourceMappingURL=explicitNull.js.map
 
 /***/ }),
-/* 347 */
+/* 348 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43602,7 +44022,7 @@ function keysOfValidator(propType) {
 //# sourceMappingURL=keysOf.js.map
 
 /***/ }),
-/* 348 */
+/* 349 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43687,7 +44107,7 @@ function mutuallyExclusiveOfType(propType) {
 //# sourceMappingURL=mutuallyExclusiveProps.js.map
 
 /***/ }),
-/* 349 */
+/* 350 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43774,7 +44194,7 @@ function mutuallyExclusiveTrue() {
 //# sourceMappingURL=mutuallyExclusiveTrueProps.js.map
 
 /***/ }),
-/* 350 */
+/* 351 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43831,7 +44251,7 @@ function nChildren(n) {
 //# sourceMappingURL=nChildren.js.map
 
 /***/ }),
-/* 351 */
+/* 352 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43898,7 +44318,7 @@ exports['default'] = function () {
 //# sourceMappingURL=numericString.js.map
 
 /***/ }),
-/* 352 */
+/* 353 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -43981,7 +44401,7 @@ function or(validators) {
 //# sourceMappingURL=or.js.map
 
 /***/ }),
-/* 353 */
+/* 354 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44029,7 +44449,7 @@ function range(min, max) {
 //# sourceMappingURL=range.js.map
 
 /***/ }),
-/* 354 */
+/* 355 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44068,7 +44488,7 @@ exports['default'] = function () {
 //# sourceMappingURL=restrictedProp.js.map
 
 /***/ }),
-/* 355 */
+/* 356 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44167,7 +44587,7 @@ function uniqueArrayOfTypeValidator(type) {
 //# sourceMappingURL=uniqueArrayOf.js.map
 
 /***/ }),
-/* 356 */
+/* 357 */
 /***/ (function(module, exports) {
 
 module.exports = function(module) {
@@ -44195,7 +44615,7 @@ module.exports = function(module) {
 
 
 /***/ }),
-/* 357 */
+/* 358 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var map = {
@@ -44444,10 +44864,10 @@ webpackContext.keys = function webpackContextKeys() {
 };
 webpackContext.resolve = webpackContextResolve;
 module.exports = webpackContext;
-webpackContext.id = 357;
+webpackContext.id = 358;
 
 /***/ }),
-/* 358 */
+/* 359 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44455,7 +44875,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports['default'] = normalizeEventOptions;
 
-var _canUsePassiveEventListeners = __webpack_require__(359);
+var _canUsePassiveEventListeners = __webpack_require__(360);
 
 var _canUsePassiveEventListeners2 = _interopRequireDefault(_canUsePassiveEventListeners);
 
@@ -44478,7 +44898,7 @@ function normalizeEventOptions(eventOptions) {
 }
 
 /***/ }),
-/* 359 */
+/* 360 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44486,7 +44906,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports['default'] = canUsePassiveEventListeners;
 
-var _canUseDOM = __webpack_require__(360);
+var _canUseDOM = __webpack_require__(361);
 
 var _canUseDOM2 = _interopRequireDefault(_canUseDOM);
 
@@ -44532,7 +44952,7 @@ function canUsePassiveEventListeners() {
 }
 
 /***/ }),
-/* 360 */
+/* 361 */
 /***/ (function(module, exports) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44543,7 +44963,7 @@ var CAN_USE_DOM = !!(typeof window !== 'undefined' && window.document && window.
 exports['default'] = CAN_USE_DOM;
 
 /***/ }),
-/* 361 */
+/* 362 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44552,7 +44972,7 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _eventOptionsKey = __webpack_require__(362);
+var _eventOptionsKey = __webpack_require__(363);
 
 var _eventOptionsKey2 = _interopRequireDefault(_eventOptionsKey);
 
@@ -44677,7 +45097,7 @@ var TargetEventHandlers = function () {
 exports['default'] = TargetEventHandlers;
 
 /***/ }),
-/* 362 */
+/* 363 */
 /***/ (function(module, exports) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -44715,7 +45135,7 @@ function eventOptionsKey(normalizedEventOptions) {
 }
 
 /***/ }),
-/* 363 */
+/* 364 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -44734,15 +45154,15 @@ function eventOptionsKey(normalizedEventOptions) {
 
 
 var ReactDOMComponentTree = __webpack_require__(10);
-var ReactDefaultInjection = __webpack_require__(364);
+var ReactDefaultInjection = __webpack_require__(365);
 var ReactMount = __webpack_require__(271);
 var ReactReconciler = __webpack_require__(35);
 var ReactUpdates = __webpack_require__(22);
-var ReactVersion = __webpack_require__(442);
+var ReactVersion = __webpack_require__(443);
 
-var findDOMNode = __webpack_require__(443);
+var findDOMNode = __webpack_require__(444);
 var getHostComponentFromComposite = __webpack_require__(272);
-var renderSubtreeIntoContainer = __webpack_require__(444);
+var renderSubtreeIntoContainer = __webpack_require__(445);
 var warning = __webpack_require__(3);
 
 ReactDefaultInjection.inject();
@@ -44819,9 +45239,9 @@ if (process.env.NODE_ENV !== 'production') {
 
 if (process.env.NODE_ENV !== 'production') {
   var ReactInstrumentation = __webpack_require__(19);
-  var ReactDOMUnknownPropertyHook = __webpack_require__(445);
-  var ReactDOMNullInputValuePropHook = __webpack_require__(446);
-  var ReactDOMInvalidARIAHook = __webpack_require__(447);
+  var ReactDOMUnknownPropertyHook = __webpack_require__(446);
+  var ReactDOMNullInputValuePropHook = __webpack_require__(447);
+  var ReactDOMInvalidARIAHook = __webpack_require__(448);
 
   ReactInstrumentation.debugTool.addHook(ReactDOMUnknownPropertyHook);
   ReactInstrumentation.debugTool.addHook(ReactDOMNullInputValuePropHook);
@@ -44832,7 +45252,7 @@ module.exports = ReactDOM;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 364 */
+/* 365 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -44848,25 +45268,25 @@ module.exports = ReactDOM;
 
 
 
-var ARIADOMPropertyConfig = __webpack_require__(365);
-var BeforeInputEventPlugin = __webpack_require__(366);
-var ChangeEventPlugin = __webpack_require__(370);
-var DefaultEventPluginOrder = __webpack_require__(378);
-var EnterLeaveEventPlugin = __webpack_require__(379);
-var HTMLDOMPropertyConfig = __webpack_require__(380);
-var ReactComponentBrowserEnvironment = __webpack_require__(381);
-var ReactDOMComponent = __webpack_require__(387);
+var ARIADOMPropertyConfig = __webpack_require__(366);
+var BeforeInputEventPlugin = __webpack_require__(367);
+var ChangeEventPlugin = __webpack_require__(371);
+var DefaultEventPluginOrder = __webpack_require__(379);
+var EnterLeaveEventPlugin = __webpack_require__(380);
+var HTMLDOMPropertyConfig = __webpack_require__(381);
+var ReactComponentBrowserEnvironment = __webpack_require__(382);
+var ReactDOMComponent = __webpack_require__(388);
 var ReactDOMComponentTree = __webpack_require__(10);
-var ReactDOMEmptyComponent = __webpack_require__(413);
-var ReactDOMTreeTraversal = __webpack_require__(414);
-var ReactDOMTextComponent = __webpack_require__(415);
-var ReactDefaultBatchingStrategy = __webpack_require__(416);
-var ReactEventListener = __webpack_require__(417);
-var ReactInjection = __webpack_require__(419);
-var ReactReconcileTransaction = __webpack_require__(420);
-var SVGDOMPropertyConfig = __webpack_require__(426);
-var SelectEventPlugin = __webpack_require__(427);
-var SimpleEventPlugin = __webpack_require__(428);
+var ReactDOMEmptyComponent = __webpack_require__(414);
+var ReactDOMTreeTraversal = __webpack_require__(415);
+var ReactDOMTextComponent = __webpack_require__(416);
+var ReactDefaultBatchingStrategy = __webpack_require__(417);
+var ReactEventListener = __webpack_require__(418);
+var ReactInjection = __webpack_require__(420);
+var ReactReconcileTransaction = __webpack_require__(421);
+var SVGDOMPropertyConfig = __webpack_require__(427);
+var SelectEventPlugin = __webpack_require__(428);
+var SimpleEventPlugin = __webpack_require__(429);
 
 var alreadyInjected = false;
 
@@ -44923,7 +45343,7 @@ module.exports = {
 };
 
 /***/ }),
-/* 365 */
+/* 366 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45002,7 +45422,7 @@ var ARIADOMPropertyConfig = {
 module.exports = ARIADOMPropertyConfig;
 
 /***/ }),
-/* 366 */
+/* 367 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45020,9 +45440,9 @@ module.exports = ARIADOMPropertyConfig;
 
 var EventPropagators = __webpack_require__(45);
 var ExecutionEnvironment = __webpack_require__(11);
-var FallbackCompositionState = __webpack_require__(367);
-var SyntheticCompositionEvent = __webpack_require__(368);
-var SyntheticInputEvent = __webpack_require__(369);
+var FallbackCompositionState = __webpack_require__(368);
+var SyntheticCompositionEvent = __webpack_require__(369);
+var SyntheticInputEvent = __webpack_require__(370);
 
 var END_KEYCODES = [9, 13, 27, 32]; // Tab, Return, Esc, Space
 var START_KEYCODE = 229;
@@ -45391,7 +45811,7 @@ var BeforeInputEventPlugin = {
 module.exports = BeforeInputEventPlugin;
 
 /***/ }),
-/* 367 */
+/* 368 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45491,7 +45911,7 @@ PooledClass.addPoolingTo(FallbackCompositionState);
 module.exports = FallbackCompositionState;
 
 /***/ }),
-/* 368 */
+/* 369 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45532,7 +45952,7 @@ SyntheticEvent.augmentClass(SyntheticCompositionEvent, CompositionEventInterface
 module.exports = SyntheticCompositionEvent;
 
 /***/ }),
-/* 369 */
+/* 370 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45574,7 +45994,7 @@ SyntheticEvent.augmentClass(SyntheticInputEvent, InputEventInterface);
 module.exports = SyntheticInputEvent;
 
 /***/ }),
-/* 370 */
+/* 371 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45891,7 +46311,7 @@ var ChangeEventPlugin = {
 module.exports = ChangeEventPlugin;
 
 /***/ }),
-/* 371 */
+/* 372 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -45908,7 +46328,7 @@ module.exports = ChangeEventPlugin;
 
 
 
-var ReactOwner = __webpack_require__(372);
+var ReactOwner = __webpack_require__(373);
 
 var ReactRef = {};
 
@@ -45985,7 +46405,7 @@ ReactRef.detachRefs = function (instance, element) {
 module.exports = ReactRef;
 
 /***/ }),
-/* 372 */
+/* 373 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46084,7 +46504,7 @@ module.exports = ReactOwner;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 373 */
+/* 374 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46101,12 +46521,12 @@ module.exports = ReactOwner;
 
 
 
-var ReactInvalidSetStateWarningHook = __webpack_require__(374);
-var ReactHostOperationHistoryHook = __webpack_require__(375);
+var ReactInvalidSetStateWarningHook = __webpack_require__(375);
+var ReactHostOperationHistoryHook = __webpack_require__(376);
 var ReactComponentTreeHook = __webpack_require__(14);
 var ExecutionEnvironment = __webpack_require__(11);
 
-var performanceNow = __webpack_require__(376);
+var performanceNow = __webpack_require__(377);
 var warning = __webpack_require__(3);
 
 var hooks = [];
@@ -46451,7 +46871,7 @@ module.exports = ReactDebugTool;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 374 */
+/* 375 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46494,7 +46914,7 @@ module.exports = ReactInvalidSetStateWarningHook;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 375 */
+/* 376 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46533,7 +46953,7 @@ var ReactHostOperationHistoryHook = {
 module.exports = ReactHostOperationHistoryHook;
 
 /***/ }),
-/* 376 */
+/* 377 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46550,7 +46970,7 @@ module.exports = ReactHostOperationHistoryHook;
  * @typechecks
  */
 
-var performance = __webpack_require__(377);
+var performance = __webpack_require__(378);
 
 var performanceNow;
 
@@ -46572,7 +46992,7 @@ if (performance.now) {
 module.exports = performanceNow;
 
 /***/ }),
-/* 377 */
+/* 378 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46600,7 +47020,7 @@ if (ExecutionEnvironment.canUseDOM) {
 module.exports = performance || {};
 
 /***/ }),
-/* 378 */
+/* 379 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46631,7 +47051,7 @@ var DefaultEventPluginOrder = ['ResponderEventPlugin', 'SimpleEventPlugin', 'Tap
 module.exports = DefaultEventPluginOrder;
 
 /***/ }),
-/* 379 */
+/* 380 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46734,7 +47154,7 @@ var EnterLeaveEventPlugin = {
 module.exports = EnterLeaveEventPlugin;
 
 /***/ }),
-/* 380 */
+/* 381 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46750,7 +47170,7 @@ module.exports = EnterLeaveEventPlugin;
 
 
 
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 
 var MUST_USE_PROPERTY = DOMProperty.injection.MUST_USE_PROPERTY;
 var HAS_BOOLEAN_VALUE = DOMProperty.injection.HAS_BOOLEAN_VALUE;
@@ -46975,7 +47395,7 @@ var HTMLDOMPropertyConfig = {
 module.exports = HTMLDOMPropertyConfig;
 
 /***/ }),
-/* 381 */
+/* 382 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -46992,7 +47412,7 @@ module.exports = HTMLDOMPropertyConfig;
 
 
 var DOMChildrenOperations = __webpack_require__(78);
-var ReactDOMIDOperations = __webpack_require__(386);
+var ReactDOMIDOperations = __webpack_require__(387);
 
 /**
  * Abstracts away all functionality of the reconciler that requires knowledge of
@@ -47008,7 +47428,7 @@ var ReactComponentBrowserEnvironment = {
 module.exports = ReactComponentBrowserEnvironment;
 
 /***/ }),
-/* 382 */
+/* 383 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -47029,7 +47449,7 @@ var _prodInvariant = __webpack_require__(5);
 var DOMLazyTree = __webpack_require__(36);
 var ExecutionEnvironment = __webpack_require__(11);
 
-var createNodesFromMarkup = __webpack_require__(383);
+var createNodesFromMarkup = __webpack_require__(384);
 var emptyFunction = __webpack_require__(16);
 var invariant = __webpack_require__(2);
 
@@ -47060,7 +47480,7 @@ module.exports = Danger;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 383 */
+/* 384 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -47081,8 +47501,8 @@ module.exports = Danger;
 
 var ExecutionEnvironment = __webpack_require__(11);
 
-var createArrayFromMixed = __webpack_require__(384);
-var getMarkupWrap = __webpack_require__(385);
+var createArrayFromMixed = __webpack_require__(385);
+var getMarkupWrap = __webpack_require__(386);
 var invariant = __webpack_require__(2);
 
 /**
@@ -47150,7 +47570,7 @@ module.exports = createNodesFromMarkup;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 384 */
+/* 385 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -47283,7 +47703,7 @@ module.exports = createArrayFromMixed;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 385 */
+/* 386 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -47384,7 +47804,7 @@ module.exports = getMarkupWrap;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 386 */
+/* 387 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -47422,7 +47842,7 @@ var ReactDOMIDOperations = {
 module.exports = ReactDOMIDOperations;
 
 /***/ }),
-/* 387 */
+/* 388 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -47443,24 +47863,24 @@ module.exports = ReactDOMIDOperations;
 var _prodInvariant = __webpack_require__(5),
     _assign = __webpack_require__(9);
 
-var AutoFocusUtils = __webpack_require__(388);
-var CSSPropertyOperations = __webpack_require__(389);
+var AutoFocusUtils = __webpack_require__(389);
+var CSSPropertyOperations = __webpack_require__(390);
 var DOMLazyTree = __webpack_require__(36);
 var DOMNamespaces = __webpack_require__(79);
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 var DOMPropertyOperations = __webpack_require__(259);
 var EventPluginHub = __webpack_require__(46);
 var EventPluginRegistry = __webpack_require__(58);
 var ReactBrowserEventEmitter = __webpack_require__(63);
 var ReactDOMComponentFlags = __webpack_require__(247);
 var ReactDOMComponentTree = __webpack_require__(10);
-var ReactDOMInput = __webpack_require__(399);
-var ReactDOMOption = __webpack_require__(400);
+var ReactDOMInput = __webpack_require__(400);
+var ReactDOMOption = __webpack_require__(401);
 var ReactDOMSelect = __webpack_require__(261);
-var ReactDOMTextarea = __webpack_require__(401);
+var ReactDOMTextarea = __webpack_require__(402);
 var ReactInstrumentation = __webpack_require__(19);
-var ReactMultiChild = __webpack_require__(402);
-var ReactServerRenderingTransaction = __webpack_require__(411);
+var ReactMultiChild = __webpack_require__(403);
+var ReactServerRenderingTransaction = __webpack_require__(412);
 
 var emptyFunction = __webpack_require__(16);
 var escapeTextContentForBrowser = __webpack_require__(62);
@@ -48438,7 +48858,7 @@ module.exports = ReactDOMComponent;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 388 */
+/* 389 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48467,7 +48887,7 @@ var AutoFocusUtils = {
 module.exports = AutoFocusUtils;
 
 /***/ }),
-/* 389 */
+/* 390 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48487,10 +48907,10 @@ var CSSProperty = __webpack_require__(258);
 var ExecutionEnvironment = __webpack_require__(11);
 var ReactInstrumentation = __webpack_require__(19);
 
-var camelizeStyleName = __webpack_require__(390);
-var dangerousStyleValue = __webpack_require__(392);
-var hyphenateStyleName = __webpack_require__(393);
-var memoizeStringOnly = __webpack_require__(395);
+var camelizeStyleName = __webpack_require__(391);
+var dangerousStyleValue = __webpack_require__(393);
+var hyphenateStyleName = __webpack_require__(394);
+var memoizeStringOnly = __webpack_require__(396);
 var warning = __webpack_require__(3);
 
 var processStyleName = memoizeStringOnly(function (styleName) {
@@ -48688,7 +49108,7 @@ module.exports = CSSPropertyOperations;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 390 */
+/* 391 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48705,7 +49125,7 @@ module.exports = CSSPropertyOperations;
 
 
 
-var camelize = __webpack_require__(391);
+var camelize = __webpack_require__(392);
 
 var msPattern = /^-ms-/;
 
@@ -48733,7 +49153,7 @@ function camelizeStyleName(string) {
 module.exports = camelizeStyleName;
 
 /***/ }),
-/* 391 */
+/* 392 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48770,7 +49190,7 @@ function camelize(string) {
 module.exports = camelize;
 
 /***/ }),
-/* 392 */
+/* 393 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48855,7 +49275,7 @@ module.exports = dangerousStyleValue;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 393 */
+/* 394 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48872,7 +49292,7 @@ module.exports = dangerousStyleValue;
 
 
 
-var hyphenate = __webpack_require__(394);
+var hyphenate = __webpack_require__(395);
 
 var msPattern = /^ms-/;
 
@@ -48899,7 +49319,7 @@ function hyphenateStyleName(string) {
 module.exports = hyphenateStyleName;
 
 /***/ }),
-/* 394 */
+/* 395 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48937,7 +49357,7 @@ function hyphenate(string) {
 module.exports = hyphenate;
 
 /***/ }),
-/* 395 */
+/* 396 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -48972,7 +49392,7 @@ function memoizeStringOnly(callback) {
 module.exports = memoizeStringOnly;
 
 /***/ }),
-/* 396 */
+/* 397 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -49003,7 +49423,7 @@ function quoteAttributeValueForBrowser(value) {
 module.exports = quoteAttributeValueForBrowser;
 
 /***/ }),
-/* 397 */
+/* 398 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -49040,7 +49460,7 @@ var ReactEventEmitterMixin = {
 module.exports = ReactEventEmitterMixin;
 
 /***/ }),
-/* 398 */
+/* 399 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -49146,7 +49566,7 @@ function getVendorPrefixedEventName(eventName) {
 module.exports = getVendorPrefixedEventName;
 
 /***/ }),
-/* 399 */
+/* 400 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -49439,7 +49859,7 @@ module.exports = ReactDOMInput;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 400 */
+/* 401 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -49567,7 +49987,7 @@ module.exports = ReactDOMOption;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 401 */
+/* 402 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -49733,7 +50153,7 @@ module.exports = ReactDOMTextarea;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 402 */
+/* 403 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -49757,10 +50177,10 @@ var ReactInstrumentation = __webpack_require__(19);
 
 var ReactCurrentOwner = __webpack_require__(20);
 var ReactReconciler = __webpack_require__(35);
-var ReactChildReconciler = __webpack_require__(403);
+var ReactChildReconciler = __webpack_require__(404);
 
 var emptyFunction = __webpack_require__(16);
-var flattenChildren = __webpack_require__(410);
+var flattenChildren = __webpack_require__(411);
 var invariant = __webpack_require__(2);
 
 /**
@@ -50185,7 +50605,7 @@ module.exports = ReactMultiChild;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 403 */
+/* 404 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -50344,7 +50764,7 @@ module.exports = ReactChildReconciler;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 404 */
+/* 405 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -50373,7 +50793,7 @@ var ReactNodeTypes = __webpack_require__(263);
 var ReactReconciler = __webpack_require__(35);
 
 if (process.env.NODE_ENV !== 'production') {
-  var checkReactTypeSpec = __webpack_require__(405);
+  var checkReactTypeSpec = __webpack_require__(406);
 }
 
 var emptyObject = __webpack_require__(52);
@@ -51250,7 +51670,7 @@ module.exports = ReactCompositeComponent;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 405 */
+/* 406 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51268,7 +51688,7 @@ module.exports = ReactCompositeComponent;
 
 var _prodInvariant = __webpack_require__(5);
 
-var ReactPropTypeLocationNames = __webpack_require__(406);
+var ReactPropTypeLocationNames = __webpack_require__(407);
 var ReactPropTypesSecret = __webpack_require__(260);
 
 var invariant = __webpack_require__(2);
@@ -51343,7 +51763,7 @@ module.exports = checkReactTypeSpec;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 406 */
+/* 407 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51374,7 +51794,7 @@ module.exports = ReactPropTypeLocationNames;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 407 */
+/* 408 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51400,7 +51820,7 @@ function getNextDebugID() {
 module.exports = getNextDebugID;
 
 /***/ }),
-/* 408 */
+/* 409 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51425,7 +51845,7 @@ var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol
 module.exports = REACT_ELEMENT_TYPE;
 
 /***/ }),
-/* 409 */
+/* 410 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51471,7 +51891,7 @@ function getIteratorFn(maybeIterable) {
 module.exports = getIteratorFn;
 
 /***/ }),
-/* 410 */
+/* 411 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51553,7 +51973,7 @@ module.exports = flattenChildren;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 411 */
+/* 412 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51574,7 +51994,7 @@ var _assign = __webpack_require__(9);
 var PooledClass = __webpack_require__(28);
 var Transaction = __webpack_require__(59);
 var ReactInstrumentation = __webpack_require__(19);
-var ReactServerUpdateQueue = __webpack_require__(412);
+var ReactServerUpdateQueue = __webpack_require__(413);
 
 /**
  * Executed within the scope of the `Transaction` instance. Consider these as
@@ -51649,7 +52069,7 @@ module.exports = ReactServerRenderingTransaction;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 412 */
+/* 413 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51794,7 +52214,7 @@ module.exports = ReactServerUpdateQueue;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 413 */
+/* 414 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -51859,7 +52279,7 @@ _assign(ReactDOMEmptyComponent.prototype, {
 module.exports = ReactDOMEmptyComponent;
 
 /***/ }),
-/* 414 */
+/* 415 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52001,7 +52421,7 @@ module.exports = {
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 415 */
+/* 416 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52169,7 +52589,7 @@ module.exports = ReactDOMTextComponent;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 416 */
+/* 417 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52242,7 +52662,7 @@ var ReactDefaultBatchingStrategy = {
 module.exports = ReactDefaultBatchingStrategy;
 
 /***/ }),
-/* 417 */
+/* 418 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52267,7 +52687,7 @@ var ReactDOMComponentTree = __webpack_require__(10);
 var ReactUpdates = __webpack_require__(22);
 
 var getEventTarget = __webpack_require__(75);
-var getUnboundedScrollPosition = __webpack_require__(418);
+var getUnboundedScrollPosition = __webpack_require__(419);
 
 /**
  * Find the deepest React component completely containing the root of the
@@ -52402,7 +52822,7 @@ var ReactEventListener = {
 module.exports = ReactEventListener;
 
 /***/ }),
-/* 418 */
+/* 419 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52446,7 +52866,7 @@ function getUnboundedScrollPosition(scrollable) {
 module.exports = getUnboundedScrollPosition;
 
 /***/ }),
-/* 419 */
+/* 420 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52462,7 +52882,7 @@ module.exports = getUnboundedScrollPosition;
 
 
 
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 var EventPluginHub = __webpack_require__(46);
 var EventPluginUtils = __webpack_require__(73);
 var ReactComponentEnvironment = __webpack_require__(82);
@@ -52485,7 +52905,7 @@ var ReactInjection = {
 module.exports = ReactInjection;
 
 /***/ }),
-/* 420 */
+/* 421 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52669,7 +53089,7 @@ module.exports = ReactReconcileTransaction;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 421 */
+/* 422 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52687,7 +53107,7 @@ module.exports = ReactReconcileTransaction;
 
 var ExecutionEnvironment = __webpack_require__(11);
 
-var getNodeForCharacterOffset = __webpack_require__(422);
+var getNodeForCharacterOffset = __webpack_require__(423);
 var getTextContentAccessor = __webpack_require__(250);
 
 /**
@@ -52886,7 +53306,7 @@ var ReactDOMSelection = {
 module.exports = ReactDOMSelection;
 
 /***/ }),
-/* 422 */
+/* 423 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52965,7 +53385,7 @@ function getNodeForCharacterOffset(root, offset) {
 module.exports = getNodeForCharacterOffset;
 
 /***/ }),
-/* 423 */
+/* 424 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -52982,7 +53402,7 @@ module.exports = getNodeForCharacterOffset;
  * 
  */
 
-var isTextNode = __webpack_require__(424);
+var isTextNode = __webpack_require__(425);
 
 /*eslint-disable no-bitwise */
 
@@ -53010,7 +53430,7 @@ function containsNode(outerNode, innerNode) {
 module.exports = containsNode;
 
 /***/ }),
-/* 424 */
+/* 425 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53027,7 +53447,7 @@ module.exports = containsNode;
  * @typechecks
  */
 
-var isNode = __webpack_require__(425);
+var isNode = __webpack_require__(426);
 
 /**
  * @param {*} object The object to check.
@@ -53040,7 +53460,7 @@ function isTextNode(object) {
 module.exports = isTextNode;
 
 /***/ }),
-/* 425 */
+/* 426 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53070,7 +53490,7 @@ function isNode(object) {
 module.exports = isNode;
 
 /***/ }),
-/* 426 */
+/* 427 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53377,7 +53797,7 @@ Object.keys(ATTRS).forEach(function (key) {
 module.exports = SVGDOMPropertyConfig;
 
 /***/ }),
-/* 427 */
+/* 428 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53570,7 +53990,7 @@ var SelectEventPlugin = {
 module.exports = SelectEventPlugin;
 
 /***/ }),
-/* 428 */
+/* 429 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53592,17 +54012,17 @@ var _prodInvariant = __webpack_require__(5);
 var EventListener = __webpack_require__(267);
 var EventPropagators = __webpack_require__(45);
 var ReactDOMComponentTree = __webpack_require__(10);
-var SyntheticAnimationEvent = __webpack_require__(429);
-var SyntheticClipboardEvent = __webpack_require__(430);
+var SyntheticAnimationEvent = __webpack_require__(430);
+var SyntheticClipboardEvent = __webpack_require__(431);
 var SyntheticEvent = __webpack_require__(23);
-var SyntheticFocusEvent = __webpack_require__(431);
-var SyntheticKeyboardEvent = __webpack_require__(432);
+var SyntheticFocusEvent = __webpack_require__(432);
+var SyntheticKeyboardEvent = __webpack_require__(433);
 var SyntheticMouseEvent = __webpack_require__(60);
-var SyntheticDragEvent = __webpack_require__(434);
-var SyntheticTouchEvent = __webpack_require__(435);
-var SyntheticTransitionEvent = __webpack_require__(436);
+var SyntheticDragEvent = __webpack_require__(435);
+var SyntheticTouchEvent = __webpack_require__(436);
+var SyntheticTransitionEvent = __webpack_require__(437);
 var SyntheticUIEvent = __webpack_require__(47);
-var SyntheticWheelEvent = __webpack_require__(437);
+var SyntheticWheelEvent = __webpack_require__(438);
 
 var emptyFunction = __webpack_require__(16);
 var getEventCharCode = __webpack_require__(87);
@@ -53802,7 +54222,7 @@ module.exports = SimpleEventPlugin;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 429 */
+/* 430 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53846,7 +54266,7 @@ SyntheticEvent.augmentClass(SyntheticAnimationEvent, AnimationEventInterface);
 module.exports = SyntheticAnimationEvent;
 
 /***/ }),
-/* 430 */
+/* 431 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53889,7 +54309,7 @@ SyntheticEvent.augmentClass(SyntheticClipboardEvent, ClipboardEventInterface);
 module.exports = SyntheticClipboardEvent;
 
 /***/ }),
-/* 431 */
+/* 432 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53930,7 +54350,7 @@ SyntheticUIEvent.augmentClass(SyntheticFocusEvent, FocusEventInterface);
 module.exports = SyntheticFocusEvent;
 
 /***/ }),
-/* 432 */
+/* 433 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -53949,7 +54369,7 @@ module.exports = SyntheticFocusEvent;
 var SyntheticUIEvent = __webpack_require__(47);
 
 var getEventCharCode = __webpack_require__(87);
-var getEventKey = __webpack_require__(433);
+var getEventKey = __webpack_require__(434);
 var getEventModifierState = __webpack_require__(77);
 
 /**
@@ -54019,7 +54439,7 @@ SyntheticUIEvent.augmentClass(SyntheticKeyboardEvent, KeyboardEventInterface);
 module.exports = SyntheticKeyboardEvent;
 
 /***/ }),
-/* 433 */
+/* 434 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54136,7 +54556,7 @@ function getEventKey(nativeEvent) {
 module.exports = getEventKey;
 
 /***/ }),
-/* 434 */
+/* 435 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54177,7 +54597,7 @@ SyntheticMouseEvent.augmentClass(SyntheticDragEvent, DragEventInterface);
 module.exports = SyntheticDragEvent;
 
 /***/ }),
-/* 435 */
+/* 436 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54227,7 +54647,7 @@ SyntheticUIEvent.augmentClass(SyntheticTouchEvent, TouchEventInterface);
 module.exports = SyntheticTouchEvent;
 
 /***/ }),
-/* 436 */
+/* 437 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54271,7 +54691,7 @@ SyntheticEvent.augmentClass(SyntheticTransitionEvent, TransitionEventInterface);
 module.exports = SyntheticTransitionEvent;
 
 /***/ }),
-/* 437 */
+/* 438 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54327,7 +54747,7 @@ SyntheticMouseEvent.augmentClass(SyntheticWheelEvent, WheelEventInterface);
 module.exports = SyntheticWheelEvent;
 
 /***/ }),
-/* 438 */
+/* 439 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54366,7 +54786,7 @@ module.exports = ReactDOMContainerInfo;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 439 */
+/* 440 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54390,7 +54810,7 @@ var ReactDOMFeatureFlags = {
 module.exports = ReactDOMFeatureFlags;
 
 /***/ }),
-/* 440 */
+/* 441 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54406,7 +54826,7 @@ module.exports = ReactDOMFeatureFlags;
 
 
 
-var adler32 = __webpack_require__(441);
+var adler32 = __webpack_require__(442);
 
 var TAG_END = /\/?>/;
 var COMMENT_START = /^<\!\-\-/;
@@ -54445,7 +54865,7 @@ var ReactMarkupChecksum = {
 module.exports = ReactMarkupChecksum;
 
 /***/ }),
-/* 441 */
+/* 442 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54494,7 +54914,7 @@ function adler32(data) {
 module.exports = adler32;
 
 /***/ }),
-/* 442 */
+/* 443 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54513,7 +54933,7 @@ module.exports = adler32;
 module.exports = '15.6.1';
 
 /***/ }),
-/* 443 */
+/* 444 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54579,7 +54999,7 @@ module.exports = findDOMNode;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 444 */
+/* 445 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54600,7 +55020,7 @@ var ReactMount = __webpack_require__(271);
 module.exports = ReactMount.renderSubtreeIntoContainer;
 
 /***/ }),
-/* 445 */
+/* 446 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54616,7 +55036,7 @@ module.exports = ReactMount.renderSubtreeIntoContainer;
 
 
 
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 var EventPluginRegistry = __webpack_require__(58);
 var ReactComponentTreeHook = __webpack_require__(14);
 
@@ -54718,7 +55138,7 @@ module.exports = ReactDOMUnknownPropertyHook;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 446 */
+/* 447 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54767,7 +55187,7 @@ module.exports = ReactDOMNullInputValuePropHook;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 447 */
+/* 448 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -54783,7 +55203,7 @@ module.exports = ReactDOMNullInputValuePropHook;
 
 
 
-var DOMProperty = __webpack_require__(24);
+var DOMProperty = __webpack_require__(25);
 var ReactComponentTreeHook = __webpack_require__(14);
 
 var warning = __webpack_require__(3);
@@ -54866,7 +55286,7 @@ module.exports = ReactDOMInvalidARIAHook;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 
 /***/ }),
-/* 448 */
+/* 449 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var moment = __webpack_require__(0);
@@ -54892,7 +55312,7 @@ module.exports = {
 
 
 /***/ }),
-/* 449 */
+/* 450 */
 /***/ (function(module, exports) {
 
 var messages = {
@@ -55002,12 +55422,12 @@ module.exports = {
 
 
 /***/ }),
-/* 450 */
+/* 451 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(89),
-    now = __webpack_require__(451),
-    toNumber = __webpack_require__(453);
+    now = __webpack_require__(452),
+    toNumber = __webpack_require__(454);
 
 /** Error message constants. */
 var FUNC_ERROR_TEXT = 'Expected a function';
@@ -55196,7 +55616,7 @@ module.exports = debounce;
 
 
 /***/ }),
-/* 451 */
+/* 452 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var root = __webpack_require__(282);
@@ -55225,7 +55645,7 @@ module.exports = now;
 
 
 /***/ }),
-/* 452 */
+/* 453 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global) {/** Detect free variable `global` from Node.js. */
@@ -55236,11 +55656,11 @@ module.exports = freeGlobal;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(270)))
 
 /***/ }),
-/* 453 */
+/* 454 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var isObject = __webpack_require__(89),
-    isSymbol = __webpack_require__(454);
+    isSymbol = __webpack_require__(455);
 
 /** Used as references for various `Number` constants. */
 var NAN = 0 / 0;
@@ -55308,11 +55728,11 @@ module.exports = toNumber;
 
 
 /***/ }),
-/* 454 */
+/* 455 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseGetTag = __webpack_require__(455),
-    isObjectLike = __webpack_require__(458);
+var baseGetTag = __webpack_require__(456),
+    isObjectLike = __webpack_require__(459);
 
 /** `Object#toString` result references. */
 var symbolTag = '[object Symbol]';
@@ -55343,12 +55763,12 @@ module.exports = isSymbol;
 
 
 /***/ }),
-/* 455 */
+/* 456 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Symbol = __webpack_require__(283),
-    getRawTag = __webpack_require__(456),
-    objectToString = __webpack_require__(457);
+    getRawTag = __webpack_require__(457),
+    objectToString = __webpack_require__(458);
 
 /** `Object#toString` result references. */
 var nullTag = '[object Null]',
@@ -55377,7 +55797,7 @@ module.exports = baseGetTag;
 
 
 /***/ }),
-/* 456 */
+/* 457 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Symbol = __webpack_require__(283);
@@ -55429,7 +55849,7 @@ module.exports = getRawTag;
 
 
 /***/ }),
-/* 457 */
+/* 458 */
 /***/ (function(module, exports) {
 
 /** Used for built-in method references. */
@@ -55457,7 +55877,7 @@ module.exports = objectToString;
 
 
 /***/ }),
-/* 458 */
+/* 459 */
 /***/ (function(module, exports) {
 
 /**
@@ -55492,7 +55912,7 @@ module.exports = isObjectLike;
 
 
 /***/ }),
-/* 459 */
+/* 460 */
 /***/ (function(module, exports) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -55504,7 +55924,7 @@ function getActiveElement() {
 }
 
 /***/ }),
-/* 460 */
+/* 461 */
 /***/ (function(module, exports) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -55516,7 +55936,7 @@ function isTransitionEndSupported() {
 }
 
 /***/ }),
-/* 461 */
+/* 462 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -55577,7 +55997,7 @@ function getCalendarMonthWeeks(month, enableOutsideDays) {
 }
 
 /***/ }),
-/* 462 */
+/* 463 */
 /***/ (function(module, exports) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -55595,7 +56015,7 @@ function getPhrase(phrase, args) {
 }
 
 /***/ }),
-/* 463 */
+/* 464 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports =
@@ -56040,7 +56460,7 @@ DayPickerKeyboardShortcuts.defaultProps = defaultProps;
 /******/ });
 
 /***/ }),
-/* 464 */
+/* 465 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports =
@@ -56555,7 +56975,7 @@ module.exports = __webpack_require__(40);
 /******/ });
 
 /***/ }),
-/* 465 */
+/* 466 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -56576,7 +56996,7 @@ module.exports = function shimValues() {
 
 
 /***/ }),
-/* 466 */
+/* 467 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports =
@@ -57505,7 +57925,7 @@ module.exports = __webpack_require__(34);
 /******/ });
 
 /***/ }),
-/* 467 */
+/* 468 */
 /***/ (function(module, exports, __webpack_require__) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -57527,411 +57947,6 @@ function isInclusivelyBeforeDay(a, b) {
   if (!_moment2['default'].isMoment(a) || !_moment2['default'].isMoment(b)) return false;
   return !(0, _isAfterDay2['default'])(a, b);
 }
-
-/***/ }),
-/* 468 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (root, factory) {
-  if (true) {
-    // AMD. Register as an anonymous module unless amdModuleId is set
-    !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0)], __WEBPACK_AMD_DEFINE_RESULT__ = function (a0) {
-      return (root['DateRange'] = factory(a0));
-    }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-  } else if (typeof exports === 'object') {
-    // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like environments that support module.exports,
-    // like Node.
-    module.exports = factory(require("moment"));
-  } else {
-    root['DateRange'] = factory(moment);
-  }
-}(this, function (moment) {
-
-//-----------------------------------------------------------------------------
-// Contstants
-//-----------------------------------------------------------------------------
-
-
-
-var INTERVALS = {
-  year:   true,
-  month:  true,
-  week:   true,
-  day:    true,
-  hour:   true,
-  minute: true,
-  second: true
-};
-
-
-//-----------------------------------------------------------------------------
-// Date Ranges
-//-----------------------------------------------------------------------------
-
-/**
- * DateRange class to store ranges and query dates.
- *
- * @constructor
- * @param {(Moment|Date)} start Start of interval
- * @param {(Moment|Date)} end End of interval
- *//**
- * DateRange class to store ranges and query dates.
- *
- * @constructor
- * @param {!Array} range Array containing start and end dates.
- *//**
- * DateRange class to store ranges and query dates.
- *
- * @constructor
- * @param {!String} range String formatted as an IS0 8601 time interval
- */
-function DateRange(start, end) {
-  var parts;
-  var s = start;
-  var e = end;
-
-  if (arguments.length === 1 || end === undefined) {
-    if (typeof start === 'object' && start.length === 2) {
-      s = start[0];
-      e = start[1];
-    }
-    else if (typeof start === 'string') {
-      parts = start.split('/');
-      s = parts[0];
-      e = parts[1];
-    }
-  }
-
-  this.start = (s === null) ? moment(-8640000000000000) : moment(s);
-  this.end   = (e === null) ? moment(8640000000000000) : moment(e);
-}
-
-/**
- * Constructor for prototype.
- *
- * @type {DateRange}
- */
-DateRange.prototype.constructor = DateRange;
-
-/**
- * Deep clone range.
- *
- * @return {!DateRange}
- */
-DateRange.prototype.clone = function() {
-  return moment().range(this.start, this.end);
-};
-
-/**
- * Determine if the current interval contains a given moment/date/range.
- *
- * @param {(Moment|Date|DateRange)} other Date to check
- * @param {!boolean} exclusive True if the to value is exclusive
- *
- * @return {!boolean}
- */
-DateRange.prototype.contains = function(other, exclusive) {
-  var start = this.start;
-  var end   = this.end;
-
-  if (other instanceof DateRange) {
-    return start <= other.start && (end > other.end || (end.isSame(other.end) && !exclusive));
-  }
-  else {
-    return start <= other && (end > other || (end.isSame(other) && !exclusive));
-  }
-};
-
-/**
- * Determine if the current date range overlaps a given date range.
- *
- * @param {!DateRange} range Date range to check
- *
- * @return {!boolean}
- */
-DateRange.prototype.overlaps = function(range) {
-  return this.intersect(range) !== null;
-};
-
-/**
- * Determine the intersecting periods from one or more date ranges.
- *
- * @param {!DateRange} other A date range to intersect with this one
- *
- * @return {DateRange} Returns the intersecting date or `null` if the ranges do
- *                     not intersect
- */
-DateRange.prototype.intersect = function(other) {
-  var start = this.start;
-  var end   = this.end;
-
-  if ((start <= other.start) && (other.start < end) && (end < other.end)) {
-    return new DateRange(other.start, end);
-  }
-  else if ((other.start < start) && (start < other.end) && (other.end <= end)) {
-    return new DateRange(start, other.end);
-  }
-  else if ((other.start < start) && (start <= end) && (end < other.end)) {
-    return this;
-  }
-  else if ((start <= other.start) && (other.start <= other.end) && (other.end <= end)) {
-    return other;
-  }
-
-  return null;
-};
-
-/**
- * Merge date ranges if they intersect.
- *
- * @param {!DateRange} other A date range to add to this one
- *
- * @return {DateRange} Returns the new `DateRange` or `null` if they do not
- *                     overlap
- */
-DateRange.prototype.add = function(other) {
-  if (this.overlaps(other)) {
-    return new DateRange(moment.min(this.start, other.start), moment.max(this.end, other.end));
-  }
-
-  return null;
-};
-
-/**
- * Subtract one range from another.
- *
- * @param {!DateRange} other A date range to substract from this one
- *
- * @return {!Array<DateRange>}
- */
-DateRange.prototype.subtract = function(other) {
-  var start = this.start;
-  var end   = this.end;
-
-  if (this.intersect(other) === null) {
-    return [this];
-  }
-  else if ((other.start <= start) && (start < end) && (end <= other.end)) {
-    return [];
-  }
-  else if ((other.start <= start) && (start < other.end) && (other.end < end)) {
-    return [new DateRange(other.end, end)];
-  }
-  else if ((start < other.start) && (other.start < end) && (end <= other.end)) {
-    return [new DateRange(start, other.start)];
-  }
-  else if ((start < other.start) && (other.start < other.end) && (other.end < end)) {
-    return [new DateRange(start, other.start), new DateRange(other.end, end)];
-  }
-  else if ((start < other.start) && (other.start < end) && (other.end < end)) {
-    return [new DateRange(start, other.start), new DateRange(other.start, end)];
-  }
-};
-
-/**
- * Build a n array of dates.
- *
- * @param {(!DateRange|String)} range Date range to be used for iteration or
- *                                    shorthand string (shorthands:
- *                                    http://momentjs.com/docs/#/manipulating/add/)
- * @param {!boolean} exclusive Indicate that the end of the range should not
- *                             be included in the iter.
- *
- * @return {!Array}
- */
-DateRange.prototype.toArray = function(by, exclusive) {
-  var acc = [];
-  this.by(by, function(unit) {
-    acc.push(unit);
-  }, exclusive);
-  return acc;
-};
-
-/**
- * Iterate over the date range by a given date range, executing a function
- * for each sub-range.
- *
- * @param {(!DateRange|String)} range Date range to be used for iteration or
- *                                    shorthand string (shorthands:
- *                                    http://momentjs.com/docs/#/manipulating/add/)
- * @param {!DateRange~by} hollaback Callback
- * @param {!boolean} exclusive Indicate that the end of the range should not
- *                             be included in the iter.
- *
- * @return {DateRange} `this`
- */
-DateRange.prototype.by = function(range, hollaback, exclusive) {
-  if (typeof range === 'string') {
-    _byString.call(this, range, hollaback, exclusive);
-  }
-  else {
-    _byRange.call(this, range, hollaback, exclusive);
-  }
-  return this;
-};
-
-
-/**
- * Callback executed for each sub-range.
- *
- * @callback DateRange~by
- *
- * @param {!Moment} current Current moment object for iteration
- */
-
-/**
- * @private
- */
-function _byString(interval, hollaback, exclusive) {
-  var current = moment(this.start);
-
-  while (this.contains(current, exclusive)) {
-    hollaback.call(this, current.clone());
-    current.add(1, interval);
-  }
-}
-
-/**
- * @private
- */
-function _byRange(interval, hollaback, exclusive) {
-  var div = this / interval;
-  var l = Math.floor(div);
-
-  if (l === Infinity) { return; }
-  if (l === div && exclusive) {
-    l--;
-  }
-
-  for (var i = 0; i <= l; i++) {
-    hollaback.call(this, moment(this.start.valueOf() + interval.valueOf() * i));
-  }
-}
-
-/**
- * Date range formatted as an [ISO8601 Time
- * Interval](http://en.wikipedia.org/wiki/ISO_8601#Time_intervals).
- *
- * @return {!String}
- */
-DateRange.prototype.toString = function() {
-  return this.start.format() + '/' + this.end.format();
-};
-
-/**
- * Date range in milliseconds. Allows basic coercion math of date ranges.
- *
- * @return {!number}
- */
-DateRange.prototype.valueOf = function() {
-  return this.end - this.start;
-};
-
-/**
- * Center date of the range.
- *
- * @return {!Moment}
- */
-DateRange.prototype.center = function() {
-  var center = this.start + this.diff() / 2;
-  return moment(center);
-};
-
-/**
- * Date range toDate
- *
- * @return {!Array<Date>}
- */
-DateRange.prototype.toDate = function() {
-  return [this.start.toDate(), this.end.toDate()];
-};
-
-/**
- * Determine if this date range is the same as another.
- *
- * @param {!DateRange} other Another date range to compare to
- *
- * @return {!boolean}
- */
-DateRange.prototype.isSame = function(other) {
-  return this.start.isSame(other.start) && this.end.isSame(other.end);
-};
-
-/**
- * The difference of the end vs start.
- *
- * @param {number} unit Unit of difference, if no unit is passed in
- *                      milliseconds are returned. E.g.: `"days"`, `"months"`,
- *                      etc...
- *
- * @return {!number}
- */
-DateRange.prototype.diff = function(unit) {
-  return this.end.diff(this.start, unit);
-};
-
-
-//-----------------------------------------------------------------------------
-// Moment Extensions
-//-----------------------------------------------------------------------------
-
-/**
- * Build a date range.
- *
- * @param {(Moment|Date)} start Start of range
- * @param {(Moment|Date)} end End of range
- *
- * @this {Moment}
- *
- * @return {!DateRange}
- */
-moment.range = function(start, end) {
-  if (start in INTERVALS) {
-    return new DateRange(moment(this).startOf(start), moment(this).endOf(start));
-  }
-  else {
-    return new DateRange(start, end);
-  }
-};
-
-/**
- * Expose constructor
- *
- * @const
- */
-moment.range.constructor = DateRange;
-
-/**
- * @deprecated
- */
-moment.fn.range = moment.range;
-
-/**
- * Check if the current moment is within a given date range.
- *
- * @param {!DateRange} range Date range to check
- *
- * @this {Moment}
- *
- * @return {!boolean}
- */
-moment.fn.within = function(range) {
-  return range.contains(this._d);
-};
-
-
-//-----------------------------------------------------------------------------
-// Export
-//-----------------------------------------------------------------------------
-
-
-
-return DateRange;
-
-}));
-
 
 /***/ }),
 /* 469 */

--- a/example/example.jsx
+++ b/example/example.jsx
@@ -1,6 +1,8 @@
 import DateRangeInput from '../lib/index.js';
 import React from 'react';
 import ReactDom from 'react-dom';
+import moment from 'moment';
+import {} from 'moment-range';
 import {} from './styles.scss';
 
 let date = new Date();
@@ -14,12 +16,27 @@ nextMonth.setMonth(date.getMonth() + 1);
 nextMonth.setDate(16);
 
 ReactDom.render(
-  <DateRangeInput />,
+  <DateRangeInput
+    defaultValue={
+      moment.range(
+        moment().startOf('day').subtract(6, 'days'),
+        moment().startOf('day')
+      )
+    }
+  />,
   document.getElementById('dateRangeExample')
 );
 
 ReactDom.render(
-  <DateRangeInput ranges={[]} />,
+  <DateRangeInput
+    ranges={[]}
+    defaultValue={
+      moment.range(
+        moment().startOf('day').subtract(6, 'days'),
+        moment().startOf('day')
+      )
+    }
+  />,
   document.getElementById('dateRangeExampleNoRanges')
 );
 

--- a/example/example.jsx
+++ b/example/example.jsx
@@ -28,7 +28,7 @@ ReactDom.render(
     minimumDate={lastMonth}
     maximumDate={nextMonth}
     ranges={[]}
-    ignoreDefault={true}
+    defaultValue={null}
     singleCalendarBreakpoint={1260}
   />,
   document.getElementById('dateRangeExampleNoRangesBlockedDates')

--- a/example/index.html
+++ b/example/index.html
@@ -7,13 +7,13 @@
 <body>
   <h1>Date Range Input Example</h1>
 
-  <h2>Basic Input</h2>
+  <h2>Basic Input (Default to last 7 days)</h2>
   <div id="dateRangeExample"></div>
 
-  <h2>No Ranges</h2>
+  <h2>No Ranges (Default to last 7 days)</h2>
   <div id="dateRangeExampleNoRanges"></div>
 
-  <h2>No Ranges and Default Value, Min/Max from 15th of last month to 15th of next month</h2>
+  <h2>No Ranges or Default Value, Min/Max from 15th of last month to 15th of next month</h2>
   <div id="dateRangeExampleNoRangesBlockedDates"></div>
 
   <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>

--- a/example/index.html
+++ b/example/index.html
@@ -13,7 +13,7 @@
   <h2>No Ranges</h2>
   <div id="dateRangeExampleNoRanges"></div>
 
-  <h2>No Ranges Min/Max from 15th of last month to 15th of next month</h2>
+  <h2>No Ranges and Default Value, Min/Max from 15th of last month to 15th of next month</h2>
   <div id="dateRangeExampleNoRangesBlockedDates"></div>
 
   <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>

--- a/lib/DateRangeInput.js
+++ b/lib/DateRangeInput.js
@@ -16,6 +16,10 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _reactDates = require('react-dates');
 
+var _reactMomentProptypes = require('react-moment-proptypes');
+
+var _reactMomentProptypes2 = _interopRequireDefault(_reactMomentProptypes);
+
 var _moment = require('moment');
 
 var _moment2 = _interopRequireDefault(_moment);
@@ -141,9 +145,9 @@ DateRangeInput.propTypes = {
   onDateSelected: _propTypes2.default.func,
   ranges: _propTypes2.default.arrayOf(_propTypes2.default.shape({
     label: _propTypes2.default.string,
-    value: _propTypes2.default.object
+    value: _reactMomentProptypes2.default.momentObj
   })),
-  defaultValue: _propTypes2.default.object,
+  defaultValue: _reactMomentProptypes2.default.momentObj,
   alwaysShowCalendar: _propTypes2.default.bool,
   singleCalendarBreakpoint: _propTypes2.default.number,
   maximumDate: _propTypes2.default.instanceOf(Date),
@@ -155,7 +159,7 @@ DateRangeInput.propTypes = {
 };
 DateRangeInput.defaultProps = {
   onDateSelected: function onDateSelected() {},
-  defaultValue: defaultRanges[2].value,
+  defaultValue: null,
   alwaysShowCalendar: true,
   singleCalendarBreakpoint: 979,
   ranges: defaultRanges,

--- a/lib/DateRangeInput.js
+++ b/lib/DateRangeInput.js
@@ -72,7 +72,7 @@ var DateRangeInput = function (_Component) {
     var startDate = null;
     var endDate = null;
 
-    if (!props.ignoreDefault && props.defaultValue && props.defaultValue.start && props.defaultValue.end) {
+    if (props.defaultValue && props.defaultValue.start && props.defaultValue.end) {
       value = props.defaultValue;
       startDate = props.defaultValue.start;
       endDate = props.defaultValue.end;
@@ -144,7 +144,6 @@ DateRangeInput.propTypes = {
     value: _propTypes2.default.object
   })),
   defaultValue: _propTypes2.default.object,
-  ignoreDefault: _propTypes2.default.bool,
   alwaysShowCalendar: _propTypes2.default.bool,
   singleCalendarBreakpoint: _propTypes2.default.number,
   maximumDate: _propTypes2.default.instanceOf(Date),
@@ -157,7 +156,6 @@ DateRangeInput.propTypes = {
 DateRangeInput.defaultProps = {
   onDateSelected: function onDateSelected() {},
   defaultValue: defaultRanges[2].value,
-  ignoreDefault: false,
   alwaysShowCalendar: true,
   singleCalendarBreakpoint: 979,
   ranges: defaultRanges,
@@ -213,7 +211,7 @@ var _initialiseProps = function _initialiseProps() {
   this.hasValidDate = function () {
     var isValid = false;
 
-    if (_this3.state.value && _this3.state.value.start instanceof _moment2.default && _this3.state.value.start instanceof _moment2.default) {
+    if (_this3.state.value && _this3.state.value.start instanceof _moment2.default && _this3.state.value.end instanceof _moment2.default) {
       isValid = true;
     }
 
@@ -309,11 +307,19 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.clearSelectedRange = function () {
-    _this3.setState({
+    var clearValue = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+
+    var newState = {
       startDate: null,
       endDate: null,
       focusedInput: 'startDate'
-    });
+    };
+
+    if (clearValue) {
+      newState.value = null;
+    }
+
+    _this3.setState(newState);
   };
 
   this.handleIsOutsideRange = function (day) {

--- a/modules/DateRangeInput.jsx
+++ b/modules/DateRangeInput.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {DayPickerRangeController} from 'react-dates';
+import momentProptypes from 'react-moment-proptypes';
 import moment from 'moment';
 import {} from 'moment-range';
 import classnames from 'classnames';
@@ -84,9 +85,9 @@ class DateRangeInput extends Component {
     onDateSelected: PropTypes.func,
     ranges: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string,
-      value: PropTypes.object
+      value: momentProptypes.momentObj
     })),
-    defaultValue: PropTypes.object,
+    defaultValue: momentProptypes.momentObj,
     alwaysShowCalendar: PropTypes.bool,
     singleCalendarBreakpoint: PropTypes.number,
     maximumDate: PropTypes.instanceOf(Date),
@@ -99,7 +100,7 @@ class DateRangeInput extends Component {
 
   static defaultProps = {
     onDateSelected: () => {},
-    defaultValue: defaultRanges[2].value,
+    defaultValue: null,
     alwaysShowCalendar: true,
     singleCalendarBreakpoint: 979,
     ranges: defaultRanges,

--- a/modules/DateRangeInput.jsx
+++ b/modules/DateRangeInput.jsx
@@ -60,8 +60,7 @@ class DateRangeInput extends Component {
     let startDate = null;
     let endDate = null;
 
-    if (!props.ignoreDefault
-      && props.defaultValue
+    if (props.defaultValue
       && props.defaultValue.start
       && props.defaultValue.end
     ) {
@@ -88,7 +87,6 @@ class DateRangeInput extends Component {
       value: PropTypes.object
     })),
     defaultValue: PropTypes.object,
-    ignoreDefault: PropTypes.bool,
     alwaysShowCalendar: PropTypes.bool,
     singleCalendarBreakpoint: PropTypes.number,
     maximumDate: PropTypes.instanceOf(Date),
@@ -102,7 +100,6 @@ class DateRangeInput extends Component {
   static defaultProps = {
     onDateSelected: () => {},
     defaultValue: defaultRanges[2].value,
-    ignoreDefault: false,
     alwaysShowCalendar: true,
     singleCalendarBreakpoint: 979,
     ranges: defaultRanges,
@@ -164,18 +161,18 @@ class DateRangeInput extends Component {
     }
   };
 
-  hasValidDate= () => {
+  hasValidDate = () => {
     let isValid = false;
 
     if (this.state.value
       && this.state.value.start instanceof moment
-      && this.state.value.start instanceof moment
+      && this.state.value.end instanceof moment
     ) {
       isValid = true;
     }
 
     return isValid;
-  }
+  };
 
   getDisplayValue = () => {
     let displayValue = this.props.defaultDisplayValue;
@@ -272,12 +269,18 @@ class DateRangeInput extends Component {
     });
   };
 
-  clearSelectedRange = () => {
-    this.setState({
+  clearSelectedRange = (clearValue = false) => {
+    let newState = {
       startDate: null,
       endDate: null,
       focusedInput: 'startDate'
-    });
+    };
+
+    if (clearValue) {
+      newState.value = null;
+    }
+
+    this.setState(newState);
   };
 
   handleIsOutsideRange = (day) => {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "classnames": "^2.2.5",
     "moment": "^2.10.6",
     "moment-range": "^2.0.3",
-    "react-dates": "^12.7.0"
+    "react-dates": "^12.7.0",
+    "react-moment-proptypes": "^1.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -45,13 +46,13 @@
     "css-loader": "^0.28.0",
     "eslint": "^4.2.0",
     "eslint-plugin-react": "^7.1.0",
+    "file-loader": "^1.1.5",
     "node-sass": "^4.5.3",
     "react": "^15.6.1",
     "react-addons-shallow-compare": "^15.6.0",
     "react-dom": "^15.6.1",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
-    "file-loader": "^1.1.5",
     "url-loader": "^0.5.9",
     "webpack": "^3.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddm-date-range-input",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "React Date Range Input and Picker",
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ var path = require('path');
 
 module.exports = {
   entry: path.resolve(
-      __dirname,
-      'example/example.jsx'
+    __dirname,
+    'example/example.jsx'
   ),
   output: {
     filename: 'example/example.js'


### PR DESCRIPTION
To render a DatePicker with a default placeholder text, we just need to pass the `defaltValue={null}` prop to the component.

+ Removes the `ignoreDefault` property
+ Fixes the `hasValidDate` method to check the end date
+ Adds a bool param to `clearSelectedRange` method to clear the default value
+ Updates package.json with a new version 2.2.0
+ Updates README.md